### PR TITLE
chore: add a Nix flake (packages, devshells)

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,10 @@ target/
 #.idea/
 
 .env
+
+# Nix
+result
+result-*
+
+# direnv
+.direnv/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,116 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1727316705,
+        "narHash": "sha256-/mumx8AQ5xFuCJqxCIOFCHTVlxHkMT21idpbgbm/TIE=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "5b03654ce046b5167e7b0bccbd8244cb56c16f0e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "devshell": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1722113426,
+        "narHash": "sha256-Yo/3loq572A8Su6aY5GP56knpuKYRvM2a1meP9oJZCw=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "67cce7359e4cd3c45296fb4aaf6a19e2a9c757ae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1726153070,
+        "narHash": "sha256-HO4zgY0ekfwO5bX0QH/3kJ/h4KvUDFZg8YpkNwIbg1U=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1727617520,
+        "narHash": "sha256-uNfh3aMyCekMpjtL/PZtl2Hz/YqNuUpCBEzVxt1QYck=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "7eee17a8a5868ecf596bbb8c8beb527253ea8f4d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1725233747,
+        "narHash": "sha256-Ss8QWLXdr2JCBPcYChJhz4xJm+h/xjl4G0c0XlP6a74=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "devshell": "devshell",
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1727431250,
+        "narHash": "sha256-uGRlRT47ecicF9iLD1G3g43jn2e+b5KaMptb59LHnvM=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "879b29ae9a0378904fbbefe0dadaed43c8905754",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,52 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    treefmt-nix.url = "github:numtide/treefmt-nix";
+    treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
+    crane.url = "github:ipetkov/crane";
+
+    devshell.url = "github:numtide/devshell";
+    devshell.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = inputs:
+    inputs.flake-parts.lib.mkFlake {inherit inputs;} ({config, ...}: {
+      imports = [
+        inputs.devshell.flakeModule
+        inputs.treefmt-nix.flakeModule
+      ];
+
+      flake.internal =
+        inputs.nixpkgs.lib.genAttrs config.systems (
+          targetSystem: import ./nix/internal/unix.nix {inherit inputs targetSystem;}
+        )
+        // inputs.nixpkgs.lib.genAttrs ["x86_64-windows"] (
+          targetSystem: import ./nix/internal/windows.nix {inherit inputs targetSystem;}
+        );
+
+      systems = ["x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin"];
+      perSystem = {
+        config,
+        system,
+        pkgs,
+        ...
+      }: {
+        packages =
+          {
+            default = inputs.self.internal.${system}.package;
+          }
+          // (inputs.nixpkgs.lib.optionalAttrs (system == "x86_64-linux") {
+            default-x86_64-windows = inputs.self.internal.x86_64-windows.package;
+          });
+
+        devshells.default = import ./nix/devshells.nix {inherit inputs;};
+
+        treefmt = {
+          projectRootFile = "flake.nix";
+          programs.alejandra.enable = true;
+          programs.rustfmt.enable = true;
+        };
+      };
+    });
+}

--- a/nix/devshells.nix
+++ b/nix/devshells.nix
@@ -1,0 +1,40 @@
+{inputs}: {
+  config,
+  pkgs,
+  ...
+}: let
+  inherit (pkgs) lib;
+in {
+  name = "blockfrost-platform-devshell";
+
+  imports = [
+    "${inputs.devshell}/extra/language/c.nix"
+    "${inputs.devshell}/extra/language/rust.nix"
+  ];
+
+  devshell.packages =
+    lib.optionals pkgs.stdenv.isLinux [
+      pkgs.pkg-config
+    ]
+    ++ lib.optionals pkgs.stdenv.isDarwin [
+      pkgs.libiconv
+    ];
+
+  commands = [
+    {package = inputs.self.formatter.${pkgs.system};}
+  ];
+
+  language.c.compiler =
+    if pkgs.stdenv.isLinux
+    then pkgs.gcc
+    else pkgs.clang;
+  language.c.includes = inputs.self.internal.${pkgs.system}.commonArgs.buildInputs;
+
+  devshell.motd = ''
+
+    {202}🔨 Welcome to ${config.name}{reset}
+    $(menu)
+
+    You can now run ‘{bold}cargo run{reset}’.
+  '';
+}

--- a/nix/internal/unix.nix
+++ b/nix/internal/unix.nix
@@ -1,0 +1,40 @@
+{
+  inputs,
+  targetSystem,
+}:
+# For now, let's keep all UNIX definitions together, until they diverge more in the future.
+assert __elem targetSystem ["x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin"]; let
+  buildSystem = targetSystem;
+  pkgs = inputs.nixpkgs.legacyPackages.${buildSystem};
+  inherit (pkgs) lib;
+in rec {
+  craneLib = inputs.crane.mkLib pkgs;
+
+  src = craneLib.cleanCargoSource ../../.;
+
+  commonArgs = {
+    inherit src;
+    strictDeps = true;
+    nativeBuildInputs = lib.optionals pkgs.stdenv.isLinux [
+      pkgs.pkg-config
+    ];
+    buildInputs =
+      lib.optionals pkgs.stdenv.isLinux [
+        pkgs.openssl
+      ]
+      ++ lib.optionals pkgs.stdenv.isDarwin [
+        pkgs.libiconv
+        pkgs.darwin.apple_sdk_12_3.frameworks.SystemConfiguration
+        pkgs.darwin.apple_sdk_12_3.frameworks.Security
+        pkgs.darwin.apple_sdk_12_3.frameworks.CoreFoundation
+      ];
+  };
+
+  # For better caching:
+  cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+
+  package = craneLib.buildPackage (commonArgs
+    // {
+      inherit cargoArtifacts;
+    });
+}

--- a/nix/internal/windows.nix
+++ b/nix/internal/windows.nix
@@ -1,0 +1,14 @@
+{
+  inputs,
+  targetSystem,
+}:
+assert __elem targetSystem ["x86_64-windows"]; let
+  buildSystem = "x86_64-linux";
+  pkgs = inputs.nixpkgs.legacyPackages.${buildSystem};
+  inherit (pkgs) lib;
+in rec {
+  package = pkgs.runCommandNoCC "blockfrost-platform" {} ''
+    echo >&2 'fatal: unimplemented'
+    exit 1
+  '';
+}


### PR DESCRIPTION
Tracked in [BFROST-59](https://input-output.atlassian.net/browse/BFROST-59).

Resolves #6.

## `direnv`

```
❯ cd Work/blockfrost-platform
direnv: loading ~/Work/blockfrost-platform/.envrc
direnv: using flake
direnv: nix-direnv: Using cached dev shell

🔨 Welcome to blockfrost-platform-devshell

[[general commands]]

  menu    - prints this menu
  treefmt - one CLI to format the code tree

You can now run ‘cargo run’.
```

## `nix fmt`

```
❯ nix fmt
traversed 25 files
emitted 8 files for processing
formatted 6 files (0 changed) in 0.107s
```

## `nix run`

```
❯ nix run -L . -- --help | head -1
Usage: blockfrost-platform [OPTIONS] --network <NETWORK> --node-socket-path <NODE_SOCKET_PATH> --secret <SECRET> --reward-address <REWARD_ADDRESS>
```

## `nix flake show`

```
❯ nix flake show --all-systems
git+file:///home/mw/Work/blockfrost-platform?ref=refs/heads/chore/BFROST-59-nix-flake&rev=90998461c62c64127c99e4b802070026156fa913
├───checks
│   ├───aarch64-darwin
│   │   └───treefmt: derivation 'treefmt-check'
│   ├───aarch64-linux
│   │   └───treefmt: derivation 'treefmt-check'
│   ├───x86_64-darwin
│   │   └───treefmt: derivation 'treefmt-check'
│   └───x86_64-linux
│       └───treefmt: derivation 'treefmt-check'
├───devShells
│   ├───aarch64-darwin
│   │   └───default: development environment 'blockfrost-platform-devshell'
│   ├───aarch64-linux
│   │   └───default: development environment 'blockfrost-platform-devshell'
│   ├───x86_64-darwin
│   │   └───default: development environment 'blockfrost-platform-devshell'
│   └───x86_64-linux
│       └───default: development environment 'blockfrost-platform-devshell'
├───formatter
│   ├───aarch64-darwin: package 'treefmt'
│   ├───aarch64-linux: package 'treefmt'
│   ├───x86_64-darwin: package 'treefmt'
│   └───x86_64-linux: package 'treefmt'
├───internal: unknown
└───packages
    ├───aarch64-darwin
    │   └───default: package 'blockfrost-platform-0.0.1'
    ├───aarch64-linux
    │   └───default: package 'blockfrost-platform-0.0.1'
    ├───x86_64-darwin
    │   └───default: package 'blockfrost-platform-0.0.1'
    └───x86_64-linux
        ├───default: package 'blockfrost-platform-0.0.1'
        └───default-x86_64-windows: package 'blockfrost-platform'
```