### PR TITLE
chore: add cardano-node to the devshell

### DIFF
--- a/.github/workflows/nix-ci.yaml
+++ b/.github/workflows/nix-ci.yaml
@@ -23,7 +23,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          extra-conf: |
+            substituters = https://cache.nixos.org https://cache.iog.io
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
       - uses: DeterminateSystems/magic-nix-cache-action@main
+        with:
+          upstream-cache: https://cache.iog.io
       - uses: DeterminateSystems/flake-checker-action@main
       - name: Check the repository
         run: nix flake check --show-trace --print-build-logs

--- a/README.md
+++ b/README.md
@@ -69,3 +69,20 @@ blockfrost-platform [OPTIONS] --network <NETWORK> --node-address <NODE_ADDRESS> 
           Print help
   -V, --version
           Print version
+
+## Devshell
+
+This repository has a [devshell](https://github.com/numtide/devshell) configured for Linux and macOS machines, both x86-64, and AArch64. To use it, please:
+
+1. Install:
+    * [Nix](https://nixos.org/download/),
+    * [direnv](https://direnv.net/),
+    * optionally: [nix-direnv](https://github.com/nix-community/nix-direnv) for a slightly better performance, if it’s easy for you to enable, e.g. on NixOS, [nix-darwin](https://github.com/LnL7/nix-darwin), using [home-manager](https://github.com/nix-community/home-manager) etc.
+2. Enter the cloned directory.
+3. And run `direnv allow`.
+
+### Pure Nix builds
+
+You can also use `nix build` to build the package for these platforms.
+
+If in doubt, run `nix flake show`.

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,22 @@
 {
   "nodes": {
+    "cardano-node": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1727221818,
+        "narHash": "sha256-i582YpBy+hBth73JqfcjGFsJrTQeDG0NJ7vN8JLWeoI=",
+        "owner": "IntersectMBO",
+        "repo": "cardano-node",
+        "rev": "5d3da8ac771ee5ed424d6c78473c11deabb7a1f3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "IntersectMBO",
+        "ref": "9.2.1",
+        "repo": "cardano-node",
+        "type": "github"
+      }
+    },
     "crane": {
       "locked": {
         "lastModified": 1727316705,
@@ -32,6 +49,22 @@
       "original": {
         "owner": "numtide",
         "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1635892615,
+        "narHash": "sha256-harGbMZr4hzat2BWBU+Y5OYXlu+fVz7E4WeQzHi5o8A=",
+        "owner": "input-output-hk",
+        "repo": "flake-compat",
+        "rev": "eca47d3377946315596da653862d341ee5341318",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "flake-compat",
         "type": "github"
       }
     },
@@ -83,8 +116,10 @@
     },
     "root": {
       "inputs": {
+        "cardano-node": "cardano-node",
         "crane": "crane",
         "devshell": "devshell",
+        "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs",
         "treefmt-nix": "treefmt-nix"

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,10 @@
     treefmt-nix.url = "github:numtide/treefmt-nix";
     treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
     crane.url = "github:ipetkov/crane";
-
+    flake-compat.url = "github:input-output-hk/flake-compat";
+    flake-compat.flake = false;
+    cardano-node.url = "github:IntersectMBO/cardano-node/9.2.1";
+    cardano-node.flake = false; # otherwise, +2k dependencies we don’t really use
     devshell.url = "github:numtide/devshell";
     devshell.inputs.nixpkgs.follows = "nixpkgs";
   };

--- a/nix/devshells.nix
+++ b/nix/devshells.nix
@@ -22,6 +22,11 @@ in {
 
   commands = [
     {package = inputs.self.formatter.${pkgs.system};}
+    {
+      name = "cardano-node";
+      package = inputs.self.internal.${pkgs.system}.cardano-node;
+    }
+    {package = config.language.rust.packageSet.cargo;}
   ];
 
   language.c.compiler =


### PR DESCRIPTION
Tracked in [BFROST-61](https://input-output.atlassian.net/browse/BFROST-61).

## Linux (x86-64)

```
❯ cd ~/Work/blockfrost-platform
direnv: loading ~/Work/blockfrost-platform/.envrc
direnv: using flake
direnv: nix-direnv: Using cached dev shell

🔨 Welcome to blockfrost-platform-devshell

[[general commands]]

  cardano-node - The cardano full node
  cargo        - Downloads your Rust project's dependencies and builds your project
  menu         - prints this menu
  treefmt      - one CLI to format the code tree

You can now run ‘cargo run’.

direnv: export +CFLAGS +C_INCLUDE_PATH +DEVSHELL_DIR +IN_NIX_SHELL +LIBRARY_PATH +NIXPKGS_PATH +PKG_CONFIG_PATH +PRJ_DATA_DIR +PRJ_ROOT +name ~PATH ~XDG_DATA_DIRS

(63ms)

❯ cardano-node version
cardano-node 9.2.1 - linux-x86_64 - ghc-8.10
git rev 5d3da8ac771ee5ed424d6c78473c11deabb7a1f3
```

## macOS (AArch64)

```
❯ cd blockfrost-platform
direnv: loading ~/Work/blockfrost-platform/.envrc
direnv: using flake
direnv: nix-direnv: using cached dev shell

🔨 Welcome to blockfrost-platform-devshell

[[general commands]]

  cardano-node - The cardano full node
  cargo        - Downloads your Rust project's dependencies and builds your project
  menu         - prints this menu
  treefmt      - one CLI to format the code tree

You can now run ‘cargo run’.

direnv: export +CFLAGS +C_INCLUDE_PATH +DEVSHELL_DIR +IN_NIX_SHELL +LIBRARY_PATH +NIXPKGS_PATH +PKG_CONFIG_PATH +PRJ_DATA_DIR +PRJ_ROOT +RUSTDOCFLAGS +RUSTFLAGS +name ~PATH ~XDG_DATA_DIRS

(135ms)

❯ cardano-node version
cardano-node 9.2.1 - darwin-aarch64 - ghc-8.10
git rev 5d3da8ac771ee5ed424d6c78473c11deabb7a1f3
```

## macOS (x86-64)

```
❯ nix develop .#devShells.x86_64-darwin.default

🔨 Welcome to blockfrost-platform-devshell

[[general commands]]

  cardano-node - The cardano full node
  cargo        - Downloads your Rust project's dependencies and builds your project
  menu         - prints this menu
  treefmt      - one CLI to format the code tree

You can now run ‘cargo run’.

(114ms)

❯ cardano-node version
cardano-node 9.2.1 - darwin-x86_64 - ghc-8.10
git rev 5d3da8ac771ee5ed424d6c78473c11deabb7a1f3
```