### PR TITLE
chore: add a script which runs `cardano-node` on a given network

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ result-*
 
 # direnv
 .direnv/
+
+/cardano-node-configs

--- a/flake.lock
+++ b/flake.lock
@@ -17,6 +17,23 @@
         "type": "github"
       }
     },
+    "cardano-playground": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1727295084,
+        "narHash": "sha256-FaeJYpwKUHqggb9OeVoLgeXK/rw3JzRpsM28MnQcmkI=",
+        "owner": "input-output-hk",
+        "repo": "cardano-playground",
+        "rev": "b4f47fd78beec0ea1ed880d6f0b794919e0c0463",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-playground",
+        "rev": "b4f47fd78beec0ea1ed880d6f0b794919e0c0463",
+        "type": "github"
+      }
+    },
     "crane": {
       "locked": {
         "lastModified": 1727316705,
@@ -117,6 +134,7 @@
     "root": {
       "inputs": {
         "cardano-node": "cardano-node",
+        "cardano-playground": "cardano-playground",
         "crane": "crane",
         "devshell": "devshell",
         "flake-compat": "flake-compat",

--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,8 @@
     cardano-node.flake = false; # otherwise, +2k dependencies we don’t really use
     devshell.url = "github:numtide/devshell";
     devshell.inputs.nixpkgs.follows = "nixpkgs";
+    cardano-playground.url = "github:input-output-hk/cardano-playground/b4f47fd78beec0ea1ed880d6f0b794919e0c0463";
+    cardano-playground.flake = false; # otherwise, +9k dependencies in flake.lock…
   };
 
   outputs = inputs:

--- a/nix/devshells.nix
+++ b/nix/devshells.nix
@@ -4,6 +4,7 @@
   ...
 }: let
   inherit (pkgs) lib;
+  internal = inputs.self.internal.${pkgs.system};
 in {
   name = "blockfrost-platform-devshell";
 
@@ -24,16 +25,29 @@ in {
     {package = inputs.self.formatter.${pkgs.system};}
     {
       name = "cardano-node";
-      package = inputs.self.internal.${pkgs.system}.cardano-node;
+      package = internal.cardano-node;
+    }
+    {
+      name = "cardano-cli";
+      package = internal.cardano-cli;
     }
     {package = config.language.rust.packageSet.cargo;}
+    {package = pkgs.rust-analyzer;}
+    {
+      category = "handy";
+      package = internal.runNode "preview";
+    }
+    {
+      category = "handy";
+      package = internal.runNode "preprod";
+    }
   ];
 
   language.c.compiler =
     if pkgs.stdenv.isLinux
     then pkgs.gcc
     else pkgs.clang;
-  language.c.includes = inputs.self.internal.${pkgs.system}.commonArgs.buildInputs;
+  language.c.includes = internal.commonArgs.buildInputs;
 
   devshell.motd = ''
 
@@ -41,5 +55,9 @@ in {
     $(menu)
 
     You can now run ‘{bold}cargo run{reset}’.
+  '';
+
+  devshell.startup.symlink-configs.text = ''
+    ln -sfn ${internal.cardano-node-configs} $PRJ_ROOT/cardano-node-configs
   '';
 }


### PR DESCRIPTION
I added this locally when playing with the [txpipe/pallas](https://github.com/txpipe/pallas) code, perhaps it will be useful to others:

```
❯ cd blockfrost-platform

🔨 Welcome to blockfrost-platform-devshell

[[general commands]]

  cardano-cli      - The Cardano command-line interface
  cardano-node     - The cardano full node
  cargo            - Downloads your Rust project's dependencies and builds your project
  menu             - prints this menu
  rust-analyzer    - Modular compiler frontend for the Rust language
  treefmt          - one CLI to format the code tree

[handy]

  run-node-preprod - Runs cardano-node on preprod
  run-node-preview - Runs cardano-node on preview

You can now run ‘cargo run’.
```

And if you run it:

```
❯ run-node-preview
Node configuration: NodeConfiguration {…}
Listening on http://127.0.0.1:12798
…
[lenovo-x:cardano.node.startup:Info:5] [2024-10-22 11:12:24.93 UTC] startup time: 1729595545
…
[lenovo-x:cardano.node.ChainDB:Info:5] [2024-10-22 11:15:05.62 UTC] Opened db with immutable tip at f94001f0e0e4d818564d63f12189d1f3b1c5e662dc94b401af32a4cc6e997f76 at slot 62927278 and tip 39338625d743dfd88b3f9e9e970a2fb65e207fd122878cc1beafd0f2c027a79e at slot 62939560
…
```