### PR TITLE
chore: turn off `nix-ci.yaml` in PRs; keep it only on `master`

### DIFF
--- a/.github/workflows/nix-ci.yaml
+++ b/.github/workflows/nix-ci.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
 jobs:
   build:
     name: CI


### PR DESCRIPTION
As requested by @vladimirvolek.