### PR TITLE
feat: add `tx-build`: build CBOR transactions based on a recovery phrase

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,3 @@
 use flake
+
+source_env_if_exists .envrc.local

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ result-*
 
 # direnv
 .direnv/
+.envrc.local
 
 /cardano-node-configs
 

--- a/flake.nix
+++ b/flake.nix
@@ -53,6 +53,7 @@
           programs.rustfmt.enable = true;
           programs.yamlfmt.enable = true;
           programs.toml-sort.enable = true;
+          programs.shfmt.enable = true;
           settings.formatter.dockfmt = {
             command = pkgs.dockfmt;
             options = ["fmt" "--write"];

--- a/nix/devshells.nix
+++ b/nix/devshells.nix
@@ -14,7 +14,8 @@ in {
   ];
 
   devshell.packages =
-    lib.optionals pkgs.stdenv.isLinux [
+    [pkgs.unixtools.xxd]
+    ++ lib.optionals pkgs.stdenv.isLinux [
       pkgs.pkg-config
     ]
     ++ lib.optionals pkgs.stdenv.isDarwin [
@@ -31,6 +32,10 @@ in {
       name = "cardano-cli";
       package = internal.cardano-cli;
     }
+    {
+      name = "cardano-address";
+      package = internal.cardano-address;
+    }
     {package = config.language.rust.packageSet.cargo;}
     {package = pkgs.rust-analyzer;}
     {
@@ -40,6 +45,10 @@ in {
     {
       category = "handy";
       package = internal.runNode "preprod";
+    }
+    {
+      category = "handy";
+      package = internal.tx-build;
     }
   ];
 

--- a/nix/internal/tx-build.sh
+++ b/nix/internal/tx-build.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+log() {
+  local level="${1}"
+  shift
+  level=$(printf '%5s' "${level^^}")
+  local timestamp
+  timestamp=$(date -u +'%Y-%m-%dT%H:%M:%S.%6NZ')
+  if [[ -t 2 ]]; then
+    local color_reset=$'\e[0m'
+    local color_grey=$'\e[90m'
+    local color_red=$'\e[1;91m'
+    local color_green=$'\e[92m'
+    case "$level" in
+    "FATAL") level="${color_red}${level}${color_reset}" ;;
+    " INFO") level="${color_green}${level}${color_reset}" ;;
+    esac
+    timestamp="${color_grey}${timestamp}${color_reset}"
+  fi
+  echo >&2 "$timestamp" "$level" "$@"
+}
+
+if [ "$#" -ne 3 ]; then
+  log fatal "Usage: tx-build <NETWORK> <AMOUNT> <RECEIVING_ADDRESS>"
+  log info
+  log info "<NETWORK> is one of: preview, preprod, mainnet"
+  log info
+  log info "<AMOUNT> is in ADA (floating point)"
+  log info
+  log info "Also set your wallet’s RECOVERY_PHRASE environment variable,"
+  log info "e.g. add it to ‘$PRJ_ROOT/.envrc.local’."
+  log info
+  log info "Debug messages will be written to stderr, while the CBOR of the transaction to stdout."
+  exit 1
+fi
+
+NETWORK="$1"
+AMOUNT="$2"
+RECEIVING_ADDRESS="$3"
+
+case "$NETWORK" in
+mainnet)
+  NETWORK_FLAG=("--mainnet")
+  ;;
+preprod)
+  NETWORK_FLAG=("--testnet-magic" "1")
+  ;;
+preview)
+  NETWORK_FLAG=("--testnet-magic" "2")
+  ;;
+*)
+  log fatal "invalid network, choose one from: mainnet, preprod, preview"
+  exit 1
+  ;;
+esac
+
+if [ -z "${CARDANO_NODE_SOCKET_PATH:-}" ]; then
+  log fatal "CARDANO_NODE_SOCKET_PATH environment variable not set"
+  exit 1
+fi
+
+if [ -z "${RECOVERY_PHRASE:-}" ]; then
+  log fatal "RECOVERY_PHRASE environment variable not set"
+  log info "you can add it to ‘$PRJ_ROOT/.envrc.local’"
+  exit 1
+fi
+
+log info "network: $NETWORK"
+
+if ! cardano-cli address info --address "$RECEIVING_ADDRESS" >/dev/null 2>&1; then
+  log fatal "invalid receiving address: $RECEIVING_ADDRESS"
+  exit 1
+fi
+
+log info "receiving address: $RECEIVING_ADDRESS"
+log info "amount: $AMOUNT ADA"
+
+TEMP_DIR=$(mktemp -d)
+log info "using a temporary directory: $TEMP_DIR"
+
+# shellcheck disable=SC2064
+trap "rm -rf \"$TEMP_DIR\"" EXIT
+
+# Derive keys using cardano-address
+log info "deriving keys from the recovery phrase"
+echo "$RECOVERY_PHRASE" | cardano-address key from-recovery-phrase Shelley >"$TEMP_DIR/root.prv"
+
+# Derive payment key (m/1852'/1815'/0'/0/0)
+cardano-address key child 1852H/1815H/0H/0/0 <"$TEMP_DIR/root.prv" >"$TEMP_DIR/payment.prv"
+cardano-address key public --with-chain-code <"$TEMP_DIR/payment.prv" >"$TEMP_DIR/payment.pub"
+
+# Derive stake key (m/1852'/1815'/0'/2/0)
+cardano-address key child 1852H/1815H/0H/2/0 <"$TEMP_DIR/root.prv" >"$TEMP_DIR/stake.prv"
+cardano-address key public --with-chain-code <"$TEMP_DIR/stake.prv" >"$TEMP_DIR/stake.pub"
+
+# Convert payment signing key to cardano-cli format
+cardano-cli key convert-cardano-address-key \
+  --shelley-payment-key --signing-key-file "$TEMP_DIR/payment.prv" --out-file "$TEMP_DIR/payment.skey"
+
+# Extract the payment verification key
+cardano-cli key verification-key --signing-key-file "$TEMP_DIR/payment.skey" \
+  --verification-key-file "$TEMP_DIR/payment.evkey"
+
+# Convert the extended payment verification key to a non-extended key
+cardano-cli key non-extended-key \
+  --extended-verification-key-file "$TEMP_DIR/payment.evkey" \
+  --verification-key-file "$TEMP_DIR/payment.vkey"
+
+# Convert stake signing key to cardano-cli format
+cardano-cli key convert-cardano-address-key \
+  --shelley-stake-key --signing-key-file "$TEMP_DIR/stake.prv" --out-file "$TEMP_DIR/stake.skey"
+
+# Extract the stake verification key
+cardano-cli key verification-key --signing-key-file "$TEMP_DIR/stake.skey" \
+  --verification-key-file "$TEMP_DIR/stake.evkey"
+
+# Convert the extended stake verification key to a non-extended key
+cardano-cli key non-extended-key \
+  --extended-verification-key-file "$TEMP_DIR/stake.evkey" \
+  --verification-key-file "$TEMP_DIR/stake.vkey"
+
+# Generate base address using non-extended verification keys
+MY_ADDRESS=$(cardano-cli address build "${NETWORK_FLAG[@]}" \
+  --payment-verification-key-file "$TEMP_DIR/payment.vkey" \
+  --stake-verification-key-file "$TEMP_DIR/stake.vkey")
+echo "$MY_ADDRESS" >"$TEMP_DIR/payment.addr"
+log info "your address: $MY_ADDRESS"
+
+# Query UTxOs
+log info "querying UTxOs…"
+cardano-cli query utxo "${NETWORK_FLAG[@]}" --address "$MY_ADDRESS" --out-file "$TEMP_DIR/utxos.json"
+
+UTXO_COUNT=$(jq length "$TEMP_DIR/utxos.json")
+if [ "$UTXO_COUNT" -eq 0 ]; then
+  log fatal "no UTxOs found at address $MY_ADDRESS"
+  exit 1
+fi
+log info "UTxO count: $UTXO_COUNT"
+
+# Build raw transaction
+log info "building transaction…"
+
+TX_INS=()
+TOTAL_LOVELACE=0
+
+for UTXO in $(jq -r 'keys[]' "$TEMP_DIR/utxos.json"); do
+  TX_HASH=$(echo "$UTXO" | cut -d'#' -f1)
+  TX_IX=$(echo "$UTXO" | cut -d'#' -f2)
+  UTXO_AMOUNT=$(jq -r ".\"$UTXO\".value.lovelace" "$TEMP_DIR/utxos.json")
+  TX_INS+=(--tx-in "$TX_HASH#$TX_IX")
+  TOTAL_LOVELACE=$((TOTAL_LOVELACE + UTXO_AMOUNT))
+done
+
+log info "total balance: $(echo "scale=3; $TOTAL_LOVELACE / 1000000" | bc -l) ADA ($TOTAL_LOVELACE lovelace)"
+
+# Convert ADA amount to lovelace
+AMOUNT_LOVELACE=$(echo "$AMOUNT * 1000000" | bc | cut -d'.' -f1)
+
+if [ "$TOTAL_LOVELACE" -lt "$AMOUNT_LOVELACE" ]; then
+  echo >&2 "fatal: insufficient balance"
+  exit 1
+fi
+
+# Build final transaction
+FINAL_TX="$TEMP_DIR/tx.raw"
+build_output=$(cardano-cli conway transaction build \
+  "${NETWORK_FLAG[@]}" \
+  "${TX_INS[@]}" \
+  --tx-out "$RECEIVING_ADDRESS+$AMOUNT_LOVELACE" \
+  --change-address "$MY_ADDRESS" \
+  --out-file "$FINAL_TX")
+
+if [[ $build_output == "Estimated transaction fee"* ]]; then
+  log info "${build_output/Estimated/estimated}"
+else
+  log fatal "$build_output"
+fi
+
+# Sign the transaction
+SIGNED_TX="$TEMP_DIR/tx.signed"
+cardano-cli >&2 conway transaction sign \
+  --tx-body-file "$FINAL_TX" \
+  --signing-key-file "$TEMP_DIR/payment.skey" \
+  "${NETWORK_FLAG[@]}" \
+  --out-file "$SIGNED_TX"
+
+log info "all done, outputting transaction CBOR to stdout…"
+
+# Extract the cborHex from the signed transaction
+jq -r '.cborHex' "$SIGNED_TX"


### PR DESCRIPTION
Another script I found useful when playing with `POST /tx/submit` – `tx-build`.

You need to set the `RECOVERY_PHRASE=` environment variable to a recovery phrase of your wallet which will be the source of funds, and then you only give the script:
* the network,
* a receiving address,
* the amount of ADA.

See below:

```
❯ cd blockfrost-platform

🔨 Welcome to blockfrost-platform-devshell

[[general commands]]

  cardano-address  - Command-line for address and key manipulation in Cardano
  cardano-cli      - The Cardano command-line interface
  cardano-node     - The cardano full node
  cargo            - Downloads your Rust project's dependencies and builds your project
  menu             - prints this menu
  rust-analyzer    - Modular compiler frontend for the Rust language
  treefmt          - one CLI to format the code tree

[handy]

  run-node-preprod - Runs cardano-node on preprod
  run-node-preview - Runs cardano-node on preview
  tx-build         - Builds a CBOR transaction for testing ‘/tx/submit’
```

```
❯ tx-build

2024-10-30T10:50:32.862003Z FATAL Usage: tx-build <NETWORK> <AMOUNT> <RECEIVING_ADDRESS>
2024-10-30T10:50:32.863295Z  INFO
2024-10-30T10:50:32.865192Z  INFO <NETWORK> is one of: preview, preprod, mainnet
2024-10-30T10:50:32.866729Z  INFO
2024-10-30T10:50:32.867998Z  INFO <AMOUNT> is in ADA (floating point)
2024-10-30T10:50:32.869193Z  INFO
2024-10-30T10:50:32.870373Z  INFO Also set your wallet’s RECOVERY_PHRASE environment variable,
2024-10-30T10:50:32.871775Z  INFO e.g. add it to ‘/home/mw/Work/blockfrost-platform/.envrc.local’.
2024-10-30T10:50:32.873943Z  INFO
2024-10-30T10:50:32.875459Z  INFO Debug messages will be written to stderr, while the CBOR of the transaction to stdout.
```

```
❯ tx-build preview 4.0 addr_test1qrwlr6uuu2s4v850z45ezjrtj7rnld5kjxgvhjvamjecze3pmjcr2aq4yc35znkn2nfd3agwxy8n7tnaze7tyrjh2snspw9f3g

2024-10-30T10:52:21.782493Z  INFO network: preview
2024-10-30T10:52:21.796822Z  INFO receiving address: addr_test1qrwlr6uuu2s4v850z45ezjrtj7rnld5kjxgvhjvamjecze3pmjcr2aq4yc35znkn2nfd3agwxy8n7tnaze7tyrjh2snspw9f3g
2024-10-30T10:52:21.798379Z  INFO amount: 4.0 ADA
2024-10-30T10:52:21.802558Z  INFO using a temporary directory: /tmp/tmp.3Wg28NrvDd
2024-10-30T10:52:21.803948Z  INFO deriving keys from the recovery phrase
2024-10-30T10:52:21.940108Z  INFO your address: addr_test1qzv6tjc04rce4w3cet8c5fpavvs5jy5l3qkl828x0a4a2y4ukrx7v6j5t60mcl9yfyhnn09p7nextnq4qw6004hlypwq9acu7l
2024-10-30T10:52:21.941348Z  INFO querying UTxOs…
2024-10-30T10:52:22.407586Z  INFO UTxO count: 1
2024-10-30T10:52:22.408912Z  INFO building transaction…
2024-10-30T10:52:22.422203Z  INFO total balance: 9987.481 ADA (9987481849 lovelace)
2024-10-30T10:52:22.567927Z  INFO estimated transaction fee: 172717 Lovelace
2024-10-30T10:52:22.580644Z  INFO all done, outputting transaction CBOR to stdout…

84a300d9010281825820f7de632f1a070dffbd056a566c01f9884b42d1dd772d6fb4cf86e82b48a39c0901018282583900ddf1eb9ce2a1561e8f156991486b97873fb6969190cbc99ddcb3816621dcb03574152623414ed354d2d8f50e310f3f2e7d167cb20e5754271a003d09008258390099a5cb0fa8f19aba38cacf8a243d632149129f882df3a8e67f6bd512bcb0cde66a545e9fbc7ca4492f39bca1f4f265cc1503b4f7d6ff205c1b00000002530d354c021a0002a2ada100d90102818258208b83e59abc9d7a66a77be5e0825525546a595174f8b929f164fcf5052d7aab7b5840905f217a50097207e3d854b4b253a887979f1866945aca23d2d3a4d31514da1ab90b49ccb781992ad270a4a95b5b5fb131e440d668707806cf2c10d5fcc23f01f5f6
```

Now you can `POST /tx/submit` this last CBOR line, and everything works.