### PR TITLE
feat: use deadpool for a pool of Cardano node N2C connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,6 +386,7 @@ dependencies = [
  "cbor",
  "chrono",
  "clap",
+ "deadpool",
  "hex",
  "jemalloc",
  "metrics",
@@ -649,6 +650,23 @@ dependencies = [
  "quote",
  "syn 2.0.77",
 ]
+
+[[package]]
+name = "deadpool"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6541a3916932fe57768d4be0b1ffb5ec7cbf74ca8c903fdfd5c0fe8aa958f0ed"
+dependencies = [
+ "deadpool-runtime",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "debugid"
@@ -1591,6 +1609,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ pallas-primitives = "0.30.2"
 metrics = { version = "0.24", default-features = false }
 metrics-exporter-prometheus = { version = "0.16", default-features = false }
 chrono = "0.4"
+deadpool = "0.12.1"
 
 [dev-dependencies]
 rstest = "0.22.0"

--- a/src/api/metrics.rs
+++ b/src/api/metrics.rs
@@ -25,7 +25,10 @@ pub fn setup_metrics_recorder() -> PrometheusHandle {
         "HTTP calls made to blockfrost-platform API"
     );
 
-    describe_gauge!("cardano_node_connected", "Cardano node connection status");
+    describe_gauge!(
+        "cardano_node_connections",
+        "Number of currently open Cardano node N2C connections"
+    );
 
     builder
 }

--- a/src/api/root.rs
+++ b/src/api/root.rs
@@ -1,11 +1,7 @@
+use crate::node::{NodeConnPool, SyncProgress};
 use axum::{Extension, Json};
 use serde::Serialize;
-use std::sync::Arc;
-use tokio::sync::RwLock;
-
 use tracing::error;
-
-use crate::node::{Node, SyncProgress};
 
 #[derive(Serialize)]
 pub struct Response {
@@ -16,19 +12,18 @@ pub struct Response {
     pub errors: Vec<String>,
 }
 
-pub async fn route(Extension(node): Extension<Arc<RwLock<Node>>>) -> Json<Response> {
+pub async fn route(Extension(node): Extension<NodeConnPool>) -> Json<Response> {
     let mut errors = vec![];
 
-    let sync_progress = node
-        .write()
-        .await
-        .sync_progress()
-        .await
-        .inspect_err(|err| {
-            error!("{:?}", err);
-            errors.push("Failed to determine sync_percentage".to_string());
-        })
-        .ok();
+    let sync_progress = match node.get().await {
+        Ok(mut node) => node.sync_progress().await,
+        Err(err) => Err(err),
+    }
+    .inspect_err(|err| {
+        error!("{:?}", err);
+        errors.push("Failed to determine sync_percentage".to_string());
+    })
+    .ok();
 
     let response = Response {
         name: "blockfrost-platform".to_string(),

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,9 +1,8 @@
-use crate::errors::BlockfrostError;
+use crate::errors::{AppError, BlockfrostError};
 use chrono::{Duration, TimeZone, Utc};
 use metrics::gauge;
 use pallas_crypto::hash::Hasher;
 use pallas_network::{
-    facades::NodeClient,
     miniprotocols,
     miniprotocols::{
         localstate,
@@ -11,51 +10,71 @@ use pallas_network::{
     },
 };
 use pallas_traverse::wellknown;
-use tracing::{info, warn};
+use std::boxed::Box;
+use std::pin::Pin;
+use tracing::{error, info, warn};
 
-pub struct Node {
-    network_magic: u64,
-    socket: String,
+/// This represents a pool of Node2Client connections to a single `cardano-node`.
+///
+/// It can be safely cloned to multiple threads, while still sharing the same
+/// set of underlying connections to the node.
+#[derive(Clone)]
+pub struct NodeConnPool {
+    underlying: deadpool::managed::Pool<NodeConnPoolManager>,
 }
 
-impl Node {
-    /// Creates a new `Node` instance
-    pub fn new(socket: &str, network_magic: u64) -> Self {
-        Self {
-            socket: socket.to_string(),
+/// Our wrapper around [`pallas_network::facades::NodeClient`]. If you only use
+/// this, you won’t get any deadlocks, inconsistencies, etc.
+pub struct NodeConn {
+    /// Note: this is an [`Option`] *only* to satisfy the borrow checker. It’s
+    /// *always* [`Some`]. See [`NodeConnPoolManager::recycle`] for an
+    /// explanation.
+    underlying: Option<pallas_network::facades::NodeClient>,
+}
+
+impl NodeConnPool {
+    /// Creates a new pool of [`NodeConn`] connections.
+    pub fn new(
+        pool_max_size: usize,
+        socket_path: &str,
+        network_magic: u64,
+    ) -> Result<Self, AppError> {
+        let manager = NodeConnPoolManager {
             network_magic,
-        }
+            socket_path: socket_path.to_string(),
+        };
+        let underlying = deadpool::managed::Pool::builder(manager)
+            .max_size(pool_max_size)
+            .build()
+            .map_err(|err| AppError::Node(err.to_string()))?;
+        Ok(Self { underlying })
     }
 
-    /// Establishes a new NodeClient connection.
-    async fn connect(&self) -> Result<NodeClient, BlockfrostError> {
-        info!("Connecting to node socket {} ...", self.socket);
-        let node_gauge = gauge!("cardano_node_connected");
-
-        match NodeClient::connect(&self.socket, self.network_magic).await {
-            Ok(client) => {
-                info!("Connection to node was successfully established.");
-                node_gauge.set(1);
-                Ok(client)
-            }
-            Err(e) => {
-                warn!("Failed to connect to node: {:?}", e);
-                node_gauge.set(0);
-                Err(BlockfrostError::custom_400(e.to_string()))
-            }
-        }
+    /// Borrows a single [`NodeConn`] connection from the pool.
+    ///
+    /// TODO: it should probably return an [`AppError`], but with
+    /// [`BlockfrostError`] it’s much easier to integrate in request handlers.
+    /// We don’t convert them automatically.
+    pub async fn get(
+        &self,
+    ) -> Result<deadpool::managed::Object<NodeConnPoolManager>, BlockfrostError> {
+        self.underlying
+            .get()
+            .await
+            .map_err(|err| BlockfrostError::internal_server_error(format!("NodeConnPool: {}", err)))
     }
+}
 
+impl NodeConn {
     /// Submits a transaction to the connected Cardano node.
-    pub async fn submit_transaction(&self, tx: String) -> Result<String, BlockfrostError> {
+    pub async fn submit_transaction(&mut self, tx: String) -> Result<String, BlockfrostError> {
         let tx = hex::decode(tx).map_err(|e| BlockfrostError::custom_400(e.to_string()))?;
         let txid = hex::encode(Hasher::<256>::hash_cbor(&tx));
 
         let era_tx = EraTx(6, tx);
 
         // Connect to the node
-        let mut client = self.connect().await?;
-        let submission_client = client.submission();
+        let submission_client = self.underlying.as_mut().unwrap().submission();
 
         // Submit the transaction
         match submission_client.submit_tx(era_tx).await {
@@ -75,6 +94,32 @@ impl Node {
         }
     }
 
+    /// We always have to release the [`localstate::GenericClient`], even on errors,
+    /// otherwise `cardano-node` stalls. If you use this function, it’s handled for you.
+    async fn with_statequery<A, F>(&mut self, action: F) -> Result<A, BlockfrostError>
+    where
+        F: for<'a> FnOnce(
+            &'a mut localstate::GenericClient,
+        ) -> Pin<
+            Box<dyn std::future::Future<Output = Result<A, BlockfrostError>> + 'a + Sync + Send>,
+        >,
+    {
+        // Acquire the client
+        let client = self.underlying.as_mut().unwrap().statequery();
+        client.acquire(None).await?;
+
+        // Run the action and ensure the client is released afterwards
+        let result = action(client).await;
+
+        // Always release the client, even if action fails
+        if let Err(e) = client.send_release().await {
+            warn!("Failed to release client: {:?}", e);
+        }
+
+        result
+    }
+
+    /// Reports the sync progress of the node.
     pub async fn sync_progress(&mut self) -> Result<SyncProgress, BlockfrostError> {
         async fn action(
             generic_client: &mut localstate::GenericClient,
@@ -179,22 +224,10 @@ impl Node {
             })
         }
 
-        // Connect to the node
-        let mut client = self.connect().await?;
-        let generic_client = client.statequery();
-
-        // Acquire the client
-        generic_client.acquire(None).await?;
-
-        // Run the action and ensure the client is released afterward
-        let result = action(generic_client).await;
-
-        // Always release the client, even if action fails
-        if let Err(e) = generic_client.send_release().await {
-            warn!("Failed to release client: {:?}", e);
-        }
-
-        result
+        self.with_statequery(|generic_client: &mut localstate::GenericClient| {
+            Box::pin(action(generic_client))
+        })
+        .await
     }
 }
 
@@ -205,4 +238,84 @@ pub struct SyncProgress {
     epoch: u32,
     slot: u64,
     block: String,
+}
+
+pub struct NodeConnPoolManager {
+    network_magic: u64,
+    socket_path: String,
+}
+
+impl deadpool::managed::Manager for NodeConnPoolManager {
+    type Type = NodeConn;
+    type Error = AppError;
+
+    async fn create(&self) -> Result<NodeConn, AppError> {
+        info!("Connecting to node N2C socket {} ...", self.socket_path);
+
+        // TODO: maybe use `ExponentialBackoff` from `tokio-retry`, to have at
+        // least _some_ debouncing between requests, if the node is down?
+        match pallas_network::facades::NodeClient::connect(&self.socket_path, self.network_magic)
+            .await
+        {
+            Ok(conn) => {
+                info!("N2C connection to node was successfully established");
+                gauge!("cardano_node_connections").increment(1);
+                Ok(NodeConn {
+                    underlying: Some(conn),
+                })
+            }
+            Err(err) => {
+                warn!("Failed to connect to node: {:?}", err);
+                Err(AppError::Node(err.to_string()))
+            }
+        }
+    }
+
+    /// Pallas decided to make the
+    /// [`pallas_network::facades::NodeClient::abort`] take ownership of `self`.
+    /// That’s why we need our [`NodeConn::underlying`] to be an [`Option`],
+    /// because in here we only get a mutable reference. If the connection is
+    /// broken, we have to call `abort`, because it joins certain multiplexer
+    /// threads. Otherwise, it’s a resource leak.
+    async fn recycle(
+        &self,
+        conn: &mut NodeConn,
+        metrics: &deadpool::managed::Metrics,
+    ) -> deadpool::managed::RecycleResult<AppError> {
+        // Take ownership of the `NodeClient` from Pallas
+        if let Some(mut owned) = conn.underlying.take() {
+            // Check if the connection is still viable
+            //
+            // FIXME: we should be able to use `miniprotocols::keepalive`
+            // (cardano-cli does), but for some reason it’s not added to
+            // `NodeClient`? Let’s try to acquire a local state client instead:
+            let client = owned.statequery();
+
+            match client.acquire(None).await {
+                Ok(()) => {
+                    drop(client.send_release().await);
+                    // Put the `NodeClient` back into our wrapper
+                    conn.underlying = Some(owned);
+                    Ok(())
+                }
+                Err(err) => {
+                    error!(
+                        "N2C connection no longer viable: {}, {}, {:?}",
+                        self.socket_path, err, metrics
+                    );
+                    gauge!("cardano_node_connections").decrement(1);
+                    // Now call `abort` to clean up their resources:
+                    owned.abort().await;
+                    // And scrap the connection from the pool:
+                    Err(deadpool::managed::RecycleError::Backend(AppError::Node(
+                        err.to_string(),
+                    )))
+                }
+            }
+        } else {
+            Err(deadpool::managed::RecycleError::Backend(AppError::Node(
+                "deadpool called recycle twice, it never happens".to_string(),
+            )))
+        }
+    }
 }


### PR DESCRIPTION
Resolves #24

Stacked on top of #22.

This PR is adding [deadpool (★1.1k)](https://github.com/bikeshedder/deadpool), to have a shared pool of N2C connections with `cardano-node`.

As a bonus, this allows us to nicely handle cases of `cardano-node` going down. The `recycle` method in our `impl deadpool::managed::Manager` handles this. A broken connection is scraped, and `deadpool` will try to establish another one – all transparent to the user, under the same interface of simple `pool.get()`.

I was also able to submit multiple transactions over the same connection.

By default, there's just one, and—when the demand rises—up to 8 connections. You can test it with `wrk` or `httperf`:

```
❯ wrk http://0:3000/

Running 10s test @ http://0:3000/
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     2.53ms  838.98us  10.12ms   85.53%
    Req/Sec     1.99k   106.89     2.21k    75.50%
  39687 requests in 10.00s, 12.49MB read
Requests/sec:   3967.42
Transfer/sec:      1.25MB
```

```
❯ httperf --port=3000 --num-conns=10 --num-calls=1000

httperf --client=0/1 --server=localhost --port=3000 --uri=/ --send-buffer=4096 --recv-buffer=16384 --ssl-protocol=auto --num-conns=10 --num-calls=1000
Maximum connect burst length: 1

Total: connections 10 requests 10000 replies 10000 test-duration 10.647 s

Connection rate: 0.9 conn/s (1064.7 ms/conn, <=1 concurrent connections)
Connection time [ms]: min 994.4 avg 1064.7 max 1205.8 median 1048.5 stddev 69.7
Connection time [ms]: connect 0.0
Connection length [replies/conn]: 1000.000

Request rate: 939.2 req/s (1.1 ms/req)
Request size [B]: 62.0

Reply rate [replies/s]: min 924.6 avg 940.7 max 956.8 stddev 22.8 (2 samples)
Reply time [ms]: response 1.1 transfer 0.0
Reply size [B]: header 109.0 content 221.0 footer 0.0 (total 330.0)
Reply status: 1xx=0 2xx=10000 3xx=0 4xx=0 5xx=0

CPU time [s]: user 2.45 system 8.15 (user 23.0% system 76.6% total 99.6%)
Net I/O: 359.5 KB/s (2.9*10^6 bps)

Errors: total 0 client-timo 0 socket-timo 0 connrefused 0 connreset 0
Errors: fd-unavail 0 addrunavail 0 ftab-full 0 other 0
```

After such a benchmark, `GET /metrics` correctly reports that N2C connections rose to 8:

```
❯ curl -fsSL http://0:3000/metrics

# HELP http_requests_total HTTP calls made to blockfrost-platform API
# TYPE http_requests_total counter
http_requests_total{method="GET",path="/",status="200"} 91631

# HELP cardano_node_connections Number of currently open Cardano node N2C connections
# TYPE cardano_node_connections gauge
cardano_node_connections 8
```