### PR TITLE
chore: use `taplo` not `toml-sort` to format `*.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,19 @@
+[package]
+name = "blockfrost-platform"
+version = "0.0.1"
+edition = "2021"
+
 [dependencies]
 axum = "0.7.6"
-tokio = {version = "1.39.2", features = ["full"]}
+tokio = { version = "1.39.2", features = ["full"] }
 tracing = "0.1.40"
-tracing-subscriber = {version = "0.3", features = ["env-filter", "fmt"]}
-serde = {version = "1.0.210", features = ["derive"]}
-tower-http = {version = "0.6.1", features = ["full"]}
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+serde = { version = "1.0.210", features = ["derive"] }
+tower-http = { version = "0.6.1", features = ["full"] }
 tower-layer = "0.3.2"
 tower = "0.5.1"
 serde_json = "1.0.122"
-clap = {version = "4.5.18", features = ["derive"]}
+clap = { version = "4.5.18", features = ["derive"] }
 toml = "0.8.19"
 thiserror = "1.0.64"
 sentry = "0.34.0"
@@ -20,17 +25,12 @@ pallas = "0.30.2"
 hex = "0.4.3"
 cbor = "0.4.1"
 pallas-primitives = "0.30.2"
-metrics = {version = "0.24", default-features = false}
-metrics-exporter-prometheus = {version = "0.16", default-features = false}
+metrics = { version = "0.24", default-features = false }
+metrics-exporter-prometheus = { version = "0.16", default-features = false }
 
 [dev-dependencies]
 rstest = "0.22.0"
 pretty_assertions = "1.4.1"
-
-[package]
-name = "blockfrost-platform"
-version = "0.0.1"
-edition = "2021"
 
 [target.'cfg(target_env = "musl")'.dependencies]
 jemalloc = "0.3"

--- a/flake.nix
+++ b/flake.nix
@@ -52,7 +52,7 @@
           programs.alejandra.enable = true;
           programs.rustfmt.enable = true;
           programs.yamlfmt.enable = true;
-          programs.toml-sort.enable = true;
+          programs.taplo.enable = true;
           programs.shfmt.enable = true;
           settings.formatter.dockfmt = {
             command = pkgs.dockfmt;


### PR DESCRIPTION
I previously suggested `toml-sort`, but `taplo` keeps the `[package]` section at the top, which is less awkward, and it’s written in Rust, and used by other Rust teams in IOG.