### PR TITLE
chore: update `cardano-node` to 10.1.2

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,16 @@
     "cardano-node": {
       "flake": false,
       "locked": {
-        "lastModified": 1727221818,
-        "narHash": "sha256-i582YpBy+hBth73JqfcjGFsJrTQeDG0NJ7vN8JLWeoI=",
+        "lastModified": 1730468447,
+        "narHash": "sha256-yNEv7MQEcOPY9I9k9RCzeMfJY6gzuGc7K53GKNHs6v8=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "5d3da8ac771ee5ed424d6c78473c11deabb7a1f3",
+        "rev": "01bda2e2cb0a70cd95067d696dbb44665f1d680a",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "9.2.1",
+        "ref": "10.1.2",
         "repo": "cardano-node",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
     crane.url = "github:ipetkov/crane";
     flake-compat.url = "github:input-output-hk/flake-compat";
     flake-compat.flake = false;
-    cardano-node.url = "github:IntersectMBO/cardano-node/9.2.1";
+    cardano-node.url = "github:IntersectMBO/cardano-node/10.1.2";
     cardano-node.flake = false; # otherwise, +2k dependencies we don’t really use
     devshell.url = "github:numtide/devshell";
     devshell.inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
9.2.1 gets stuck on Preview on block `09e8748bf5d339893c389e0bcc3be334b98d805fed3e311d1f9c228fc9b0f565`