### PR TITLE
initial macro implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,12 +346,14 @@ version = "0.0.1"
 dependencies = [
  "axum 0.7.6",
  "blake2",
+ "blockfrost-platform-macros",
  "cbor",
  "chrono",
  "clap",
  "deadpool",
  "hex",
  "jemalloc",
+ "macro_tests",
  "metrics",
  "metrics-exporter-prometheus",
  "pallas",
@@ -374,6 +376,15 @@ dependencies = [
  "tower-layer",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "blockfrost-platform-macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1295,6 +1306,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "macro_tests"
+version = "0.1.0"
+dependencies = [
+ "blockfrost-platform-macros",
+]
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1905,9 +1923,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,8 @@ metrics = { version = "0.24", default-features = false }
 metrics-exporter-prometheus = { version = "0.16", default-features = false }
 chrono = "0.4"
 deadpool = "0.12.1"
+blockfrost-platform-macros = { path = "../blockfrost-platform-macros" }
+
 
 [dev-dependencies]
 rstest = "0.22.0"

--- a/src/cbor/codec.rs
+++ b/src/cbor/codec.rs
@@ -8,22 +8,22 @@ use crate::cbor::haskell_types::{
 impl<'b> Decode<'b, ()> for TxValidationError {
     fn decode(d: &mut Decoder<'b>, _ctx: &mut ()) -> Result<Self, decode::Error> {
         d.array()?;
-        let error = d.u16()?;
+        let error_tag = d.u16()?;
         d.array()?;
 
-        match error {
+        match error_tag {
             1 => {
-                let errors = d.decode()?;
-                Ok(TxValidationError::Byron(errors))
+                let error = d.decode()?;
+                Ok(TxValidationError::ByronTxValidationError { error })
             }
             2 => {
                 let era = d.decode()?;
-                let errors = d.decode()?;
-                Ok(TxValidationError::Shelley(errors, era))
+                let error = d.decode()?;
+                Ok(TxValidationError::ShelleyTxValidationError{error, era})
             }
             _ => Err(decode::Error::message(format!(
                 "unknown error tag while decoding TxValidationError: {}",
-                error
+                error_tag
             ))),
         }
     }
@@ -145,12 +145,12 @@ impl<'b> Decode<'b, ()> for ShelleyBasedEra {
         use ShelleyBasedEra::*;
 
         match era {
-            1 => Ok(Shelley()),
-            2 => Ok(Allegra()),
-            3 => Ok(Mary()),
-            4 => Ok(Alonzo()),
-            5 => Ok(Babbage()),
-            6 => Ok(Conway()),
+            1 => Ok(ShelleyBasedEraShelley),
+            2 => Ok(ShelleyBasedEraAllegra),
+            3 => Ok(ShelleyBasedEraMary),
+            4 => Ok(ShelleyBasedEraAlonzo),
+            5 => Ok(ShelleyBasedEraBabbage),
+            6 => Ok(ShelleyBasedEraConway),
             _ => Err(decode::Error::message(format!(
                 "unknown era while decoding ShelleyBasedEra: {}",
                 era

--- a/src/cbor/haskell_types.rs
+++ b/src/cbor/haskell_types.rs
@@ -1,5 +1,7 @@
 #![allow(dead_code)]
 
+use std::fmt;
+
 use pallas::ledger::addresses::StakeKeyHash;
 use pallas_codec::minicbor;
 use pallas_codec::minicbor::Decode;
@@ -22,21 +24,21 @@ use pallas_primitives::{
 /// https://github.com/IntersectMBO/cardano-ledger/blob/master/libs/cardano-ledger-core/src/Cardano/Ledger/Coin.hs
 
 // https://github.com/IntersectMBO/cardano-api/blob/a0df586e3a14b98ae4771a192c09391dacb44564/cardano-api/internal/Cardano/Api/Eon/ShelleyBasedEra.hs#L271
-#[derive(Debug)]
+#[derive(Debug, serde::Serialize)]
 pub enum ShelleyBasedEra {
-    Shelley(),
-    Allegra(),
-    Mary(),
-    Alonzo(),
-    Babbage(),
-    Conway(),
+    ShelleyBasedEraShelley,
+    ShelleyBasedEraAllegra,
+    ShelleyBasedEraMary,
+    ShelleyBasedEraAlonzo,
+    ShelleyBasedEraBabbage,
+    ShelleyBasedEraConway,
 }
 
-#[derive(Debug)]
+#[derive(Debug, serde::Serialize)]
 pub struct ApplyTxErr(pub Vec<ApplyConwayTxPredError>);
 
 // https://github.com/IntersectMBO/cardano-ledger/blob/aed1dc28b98c25ea73bc692e7e6c6d3a22381ff5/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs#L146
-#[derive(Debug)]
+#[derive(Debug, serde::Serialize)]
 pub enum ApplyConwayTxPredError {
     UtxowFailure(ConwayUtxoWPredFailure),
     CertsFailure(ConwayUtxoWPredFailure),
@@ -47,8 +49,25 @@ pub enum ApplyConwayTxPredError {
     MempoolFailure(String),
 }
 
+impl fmt::Display for ApplyConwayTxPredError {
+
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use ApplyConwayTxPredError::*;
+
+        match self {
+            UtxowFailure(e) => write!(f, "UtxowFailure ({})", e),
+            CertsFailure(e) => write!(f, "CertsFailure ({})", e),
+            GovFailure(e) => write!(f, "GovFailure ({})", e),
+            WdrlNotDelegatedToDRep(e) => write!(f, "WdrlNotDelegatedToDRep ({})", e),
+            TreasuryValueMismatch(e) => write!(f, "TreasuryValueMismatch ({})", e),
+            TxRefScriptsSizeTooBig(e) => write!(f, "TxRefScriptsSizeTooBig ({})", e),
+            MempoolFailure(e) => write!(f, "MempoolFailure ({})", e),
+        }
+    }
+}
+
 // https://github.com/IntersectMBO/cardano-ledger/blob/f54489071f4faa4b6209e1ba5288507c824cca50/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxow.hs
-#[derive(Debug)]
+#[derive(Debug, serde::Serialize)]
 pub enum ConwayUtxoWPredFailure {
     UtxoFailure(ConwayUtxoPredFailure),
     InvalidWitnessesUTXOW(VKeyWitness),
@@ -64,17 +83,45 @@ pub enum ConwayUtxoWPredFailure {
     MissingRequiredDatums(Vec<DatumHash>, Vec<DatumHash>), // set of missing data hashes, set of recieved data hashes
     NotAllowedSupplementalDatums(Vec<DatumHash>, Vec<DatumHash>), // set of unallowed data hashes, set of acceptable data hashes
     PPViewHashesDontMatch(Option<ScriptIntegrityHash>),
-    UnspendableUTxONoDatumHash(Vec<TxIn>), //  Set of transaction inputs that are TwoPhase scripts, and should have a DataHash but don't
-    ExtraRedeemers(Vec<PlutusPurpose>),    // List of redeemers not needed
+    UnspendableUTxONoDatumHash(Vec<SerializableTxIn>), //  Set of transaction inputs that are TwoPhase scripts, and should have a DataHash but don't
+    ExtraRedeemers(Vec<PlutusPurpose>),                // List of redeemers not needed
     MalformedScriptWitnesses(Vec<ScriptHash>),
     MalformedReferenceScripts(Vec<ScriptHash>),
 }
 
+impl fmt::Display for ConwayUtxoWPredFailure {
+
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use ConwayUtxoWPredFailure::*;
+
+        match self { 
+            UtxoFailure(e) => write!(f, "UtxoFailure ({})", e),
+            InvalidWitnessesUTXOW(e) => write!(f, "InvalidWitnessesUTXOW ({:?})", e),
+            MissingVKeyWitnessesUTXOW(e) => write!(f, "MissingVKeyWitnessesUTXOW ({:?})", e),
+            MissingScriptWitnessesUTXOW(e) => write!(f, "MissingScriptWitnessesUTXOW ({:?})", e),
+            ScriptWitnessNotValidatingUTXOW(e) => write!(f, "ScriptWitnessNotValidatingUTXOW ({:?})", e),
+            MissingTxBodyMetadataHash(e) => write!(f, "MissingTxBodyMetadataHash ({:?})", e),
+            MissingTxMetadata(e) => write!(f, "MissingTxMetadata ({:?})", e),
+            ConflictingMetadataHash(e1, e2) => write!(f, "ConflictingMetadataHash ({:?}, {:?})", e1, e2),
+            InvalidMetadata() => write!(f, "InvalidMetadata"),
+            ExtraneousScriptWitnessesUTXOW(e) => write!(f, "ExtraneousScriptWitnessesUTXOW ({:?})", e),
+            MissingRedeemers(e) => write!(f, "MissingRedeemers ({:?})", e),
+            MissingRequiredDatums(e1, e2) => write!(f, "MissingRequiredDatums ({:?}, {:?})", e1, e2),
+            NotAllowedSupplementalDatums(e1, e2) => write!(f, "NotAllowedSupplementalDatums ({:?}, {:?})", e1, e2),
+            PPViewHashesDontMatch(e) => write!(f, "PPViewHashesDontMatch ({:?})", e),
+            UnspendableUTxONoDatumHash(e) => write!(f, "UnspendableUTxONoDatumHash ({:?})", e),
+            ExtraRedeemers(e) => write!(f, "ExtraRedeemers ({:?})", e),
+            MalformedScriptWitnesses(e) => write!(f, "MalformedScriptWitnesses ({:?})", e),
+            MalformedReferenceScripts(e) => write!(f, "MalformedReferenceScripts ({:?})", e),
+        }
+    }
+}
+
 // https://github.com/IntersectMBO/cardano-ledger/blob/f54489071f4faa4b6209e1ba5288507c824cca50/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs#L315
-#[derive(Debug)]
+#[derive(Debug, serde::Serialize)]
 pub enum ConwayUtxoPredFailure {
     UtxosFailure(Box<ConwayUtxoPredFailure>),
-    BadInputsUTxO(Vec<TxIn>),
+    BadInputsUTxO(Vec<SerializableTxIn>),
     OutsideValidityIntervalUTxO(ValidityInterval, SlotNo), // validity interval, current slot
     MaxTxSizeUTxO(u64),                                    // less than or equal
     InputSetEmptyUTxO(),                                   // empty
@@ -82,9 +129,9 @@ pub enum ConwayUtxoPredFailure {
     ValueNotConservedUTxO(Value, Value),
     WrongNetwork(Network, Vec<Addr>), // the expected network id,  the set of addresses with incorrect network IDs
     WrongNetworkWithdrawal(Network, Vec<RewardAccount>), // the expected network id ,  the set of reward addresses with incorrect network IDs
-    OutputTooSmallUTxO(Vec<TxOut>),
-    OutputBootAddrAttrsTooBig(Vec<TxOut>),
-    OutputTooBigUTxO(Vec<(u64, u64, TxOut)>), //  list of supplied bad transaction output triples (actualSize,PParameterMaxValue,TxOut)
+    OutputTooSmallUTxO(Vec<SerializableTxOut>),
+    OutputBootAddrAttrsTooBig(Vec<SerializableTxOut>),
+    OutputTooBigUTxO(Vec<(u64, u64, SerializableTxOut)>), //  list of supplied bad transaction output triples (actualSize,PParameterMaxValue,TxOut)
     InsufficientCollateral(Coin, Coin), // balance computed, the required collateral for the given fee
     ScriptsNotPaidUTxO(Utxo),           // The UTxO entries which have the wrong kind of script
     ExUnitsTooBigUTxO(ExUnits),         // check: The values are serialised in reverse order
@@ -94,18 +141,53 @@ pub enum ConwayUtxoPredFailure {
     TooManyCollateralInputs(u64), // this is Haskell Natural, how many bit is it?
     NoCollateralInputs(),         // empty
     IncorrectTotalCollateralField(Coin, Coin), // collateral provided, collateral amount declared in transaction body
-    BabbageOutputTooSmallUTxO(Vec<(TxOut, Coin)>), // list of supplied transaction outputs that are too small, together with the minimum value for the given output
-    BabbageNonDisjointRefInputs(Vec<TxIn>), // TxIns that appear in both inputs and reference inputs
+    BabbageOutputTooSmallUTxO(Vec<(SerializableTxOut, Coin)>), // list of supplied transaction outputs that are too small, together with the minimum value for the given output
+    BabbageNonDisjointRefInputs(Vec<SerializableTxIn>), // TxIns that appear in both inputs and reference inputs
+}
+
+impl fmt::Display for ConwayUtxoPredFailure {
+
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use ConwayUtxoPredFailure::*;
+
+        match self {
+            UtxosFailure(e) => write!(f, "UtxosFailure ({})", e),
+            BadInputsUTxO(e) => write!(f, "BadInputsUTxO ({:?})", e),
+            OutsideValidityIntervalUTxO(vi, slot) => write!(f, "OutsideValidityIntervalUTxO ({:?}, {:?})", vi, slot),
+            MaxTxSizeUTxO(size) => write!(f, "MaxTxSizeUTxO ({})", size),
+            InputSetEmptyUTxO() => write!(f, "InputSetEmptyUTxO"),
+            FeeTooSmallUTxO(expected, supplied) => write!(f, "FeeTooSmallUTxO ({}, {})", expected, supplied),
+            ValueNotConservedUTxO(expected, supplied) => write!(f, "ValueNotConservedUTxO ({:?}, {:?})", expected, supplied),
+            WrongNetwork(network, addrs) => write!(f, "WrongNetwork ({:?}, {:?})", network, addrs),
+            WrongNetworkWithdrawal(network, accounts) => write!(f, "WrongNetworkWithdrawal ({:?}, {:?})", network, accounts),
+            OutputTooSmallUTxO(outputs) => write!(f, "OutputTooSmallUTxO ({:?})", outputs),
+            OutputBootAddrAttrsTooBig(outputs) => write!(f, "OutputBootAddrAttrsTooBig ({:?})", outputs),
+            OutputTooBigUTxO(outputs) => write!(f, "OutputTooBigUTxO ({:?})", outputs),
+            InsufficientCollateral(balance, required) => write!(f, "InsufficientCollateral ({}, {})", balance, required),
+            ScriptsNotPaidUTxO(utxo) => write!(f, "ScriptsNotPaidUTxO ({:?})", utxo),
+            ExUnitsTooBigUTxO(units) => write!(f, "ExUnitsTooBigUTxO ({:?})", units),
+            CollateralContainsNonADA(value) => write!(f, "CollateralContainsNonADA ({:?})", value),
+            WrongNetworkInTxBody() => write!(f, "WrongNetworkInTxBody"),
+            OutsideForecast(slot) => write!(f, "OutsideForecast ({})", slot),
+            TooManyCollateralInputs(inputs) => write!(f, "TooManyCollateralInputs ({})", inputs),
+            NoCollateralInputs() => write!(f, "NoCollateralInputs"),
+            IncorrectTotalCollateralField(provided, declared) => write!(f, "IncorrectTotalCollateralField ({}, {})", provided, declared),
+            BabbageOutputTooSmallUTxO(outputs) => write!(f, "BabbageOutputTooSmallUTxO ({:?})", outputs),
+            BabbageNonDisjointRefInputs(inputs) => write!(f, "BabbageNonDisjointRefInputs ({:?})", inputs),
+        }
+    }
 }
 
 // wrapping  TxValidationError (ShelleyTxValidationError or ByronTxValidationError) in TxValidationErrorInCardanoMode
 // https://github.com/IntersectMBO/cardano-api/blob/a0df586e3a14b98ae4771a192c09391dacb44564/cardano-api/internal/Cardano/Api/InMode.hs#L289
 // https://github.com/IntersectMBO/cardano-api/blob/a0df586e3a14b98ae4771a192c09391dacb44564/cardano-api/internal/Cardano/Api/InMode.hs#L204
 // toJson https://github.com/IntersectMBO/cardano-api/blob/a0df586e3a14b98ae4771a192c09391dacb44564/cardano-api/internal/Cardano/Api/InMode.hs#L233
-#[derive(Debug)]
+#[derive(Debug, serde::Serialize)]
+#[serde(tag = "kind")]
 pub enum TxValidationError {
-    Byron(ApplyTxErr),
-    Shelley(ApplyTxErr, ShelleyBasedEra),
+    
+    ByronTxValidationError{error: ApplyTxErr},
+    ShelleyTxValidationError{error: ApplyTxErr, era: ShelleyBasedEra},
 }
 
 // https://github.com/IntersectMBO/cardano-ledger/blob/f54489071f4faa4b6209e1ba5288507c824cca50/libs/cardano-ledger-core/src/Cardano/Ledger/Address.hs
@@ -114,7 +196,7 @@ pub type Addr = Bytes;
 
 // https://github.com/IntersectMBO/cardano-ledger/blob/78b20b6301b2703aa1fe1806ae3c129846708a10/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs#L497
 // not tested yet
-#[derive(Debug)]
+#[derive(Debug, serde::Serialize)]
 pub enum PlutusPurpose {
     Spending,   // 0
     Minting,    // 1
@@ -122,7 +204,7 @@ pub enum PlutusPurpose {
     Rewarding,  // 3
 }
 // https://github.com/IntersectMBO/cardano-ledger/blob/78b20b6301b2703aa1fe1806ae3c129846708a10/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs#L779
-#[derive(Debug, Decode)]
+#[derive(Debug, Decode, serde::Serialize)]
 pub enum Network {
     #[n(0)]
     Mainnet,
@@ -134,7 +216,8 @@ pub enum Network {
 type ScriptIntegrityHash = ScriptHash;
 
 // https://github.com/IntersectMBO/cardano-ledger/blob/aed1dc28b98c25ea73bc692e7e6c6d3a22381ff5/eras/allegra/impl/src/Cardano/Ledger/Allegra/Scripts.hs#L109
-#[derive(Debug, Decode)]
+#[derive(Debug, Decode, serde::Serialize)]
+
 pub struct ValidityInterval {
     #[n(0)]
     pub invalid_before: Option<SlotNo>, // SlotNo
@@ -143,7 +226,76 @@ pub struct ValidityInterval {
 }
 
 // https://github.com/IntersectMBO/cardano-ledger/blob/aed1dc28b98c25ea73bc692e7e6c6d3a22381ff5/libs/cardano-ledger-core/src/Cardano/Ledger/UTxO.hs#L83
-#[derive(Debug)]
-pub struct Utxo(pub Vec<(TxIn, TxOut)>);
+#[derive(Debug, serde::Serialize)]
+pub struct Utxo(pub Vec<(SerializableTxIn, SerializableTxOut)>);
+
+#[derive(Debug, Decode)]
+pub struct SerializableTxIn(#[n(0)] pub TxIn);
+
+impl serde::Serialize for SerializableTxIn {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        todo!()
+    }
+}
+
+#[derive(Debug, Decode)]
+pub struct SerializableTxOut(#[n(0)] pub TxOut);
+
+impl serde::Serialize for SerializableTxOut {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        todo!()
+    }
+}
 
 type SlotNo = u64;
+
+// https://github.com/IntersectMBO/ouroboros-consensus/blob/e86b921443bd6e8ea25e7190eb7cb5788e28f4cc/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/HardFork/Combinator/AcrossEras.hs#L208
+#[derive(Debug, serde::Serialize)]
+pub struct EraMismatch {
+    ledger: String, //  Name of the era of the ledger ("Byron" or "Shelley").
+    other: String,  // Era of the block, header, transaction, or query.
+}
+
+/*
+** cardano-submit-api types
+** These types are used to mimick cardano-submit-api error responses.
+*/
+
+// https://github.com/IntersectMBO/cardano-node/blob/9dbf0b141e67ec2dfd677c77c63b1673cf9c5f3e/cardano-submit-api/src/Cardano/TxSubmit/Types.hs#L54
+#[derive(serde::Serialize)]
+#[serde(tag = "tag", content = "contents")]
+pub enum TxSubmitFail {
+    TxSubmitDecodeHex,
+    TxSubmitEmpty,
+    TxSubmitDecodeFail(DecoderError),
+    TxSubmitBadTx(String),
+    TxSubmitFail(TxCmdError),
+}
+
+// https://github.com/IntersectMBO/cardano-node/blob/9dbf0b141e67ec2dfd677c77c63b1673cf9c5f3e/cardano-submit-api/src/Cardano/TxSubmit/Types.hs#L92
+#[derive(serde::Serialize)]
+#[serde(tag = "tag", content = "contents")]
+pub enum TxCmdError {
+    SocketEnvError(String),
+    TxReadError(Vec<DecoderError>),
+    TxCmdTxSubmitValidationError(TxValidationErrorInCardanoMode),
+}
+
+// Lots of errors, skipping for now. https://github.com/IntersectMBO/cardano-base/blob/391a2c5cfd30d2234097e000dbd8d9db21ef94d7/cardano-binary/src/Cardano/Binary/FromCBOR.hs#L90
+type DecoderError = String;
+
+// https://github.com/IntersectMBO/cardano-api/blob/d7c62a04ebf18d194a6ea70e6765eb7691d57668/cardano-api/internal/Cardano/Api/InMode.hs#L259
+#[derive(Debug, serde::Serialize)]
+#[serde(tag = "tag", content = "contents")]
+pub enum TxValidationErrorInCardanoMode {
+    TxValidationErrorInCardanoMode(TxValidationError),
+    EraMismatch(EraMismatch),
+}
+
+


### PR DESCRIPTION
This is my initial implementation using a macro. 
The implemented macro can mimic cardano submit api response format, like:
```
ConwayUtxowFailure (UtxoFailure (ValueNotConservedUTxO (MaryValue (Coin 9498687280) (MultiAsset (fromList []))) (MaryValue (Coin 9994617117) (MultiAsset (fromList [])))))
``` 

This is over-complicated. I think I will go with a `Display` based implementation. I do not plan to merge this PR.