### PR TITLE
ci: add ReviewDog

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,23 @@
+name: ReviewDog
+
+on:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Markdown
+        uses: reviewdog/action-markdownlint@v0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dockerfiles
+        uses: reviewdog/action-hadolint@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          filter_mode: file
+      - name: Shell scripts
+        uses: reviewdog/action-shellcheck@v1
+        with:
+          github_token: ${{ secrets.github_token }}


### PR DESCRIPTION
# Context

I am not able to quite get it properly working, I think once its merged it should be fine since on `pull_request` trigger does trigger synchronization and on `push` has no reference to PR

I kinda wish I added other linters, but I think this will do for starters

I think it is good to be merged

# Important Changes Introduced
