### PR TITLE
chore(nextra): static exports

### DIFF
--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -1,8 +1,19 @@
-import nextra from "nextra";
-
+import nextra from 'nextra'
+ 
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  images: {
+    unoptimized: true // mandatory, otherwise won't export
+  }
+  // Optional: Change the output directory `out` -> `dist`
+  // distDir: "build"
+}
 const withNextra = nextra({
-  theme: "nextra-theme-docs",
-  themeConfig: "./theme.config.tsx",
-});
-
-export default withNextra();
+  theme: 'nextra-theme-docs',
+  themeConfig: './theme.config.tsx'
+})
+ 
+export default withNextra(nextConfig)


### PR DESCRIPTION
# Context

Moving from Vercel hosting of the docs to static files hosted by Cloudflare pages.