### PR TITLE
chore: add a 10 minute timeout to `cargo test` on CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,7 @@ jobs:
         run: cargo build --release --verbose
       - name: Test
         run: cargo test --verbose
+        timeout-minutes: 10
       - name: Check formatting
         run: cargo fmt --all -- --check
       - name: Lint with Clippy


### PR DESCRIPTION
# Context

After [this 18 hour run](https://github.com/blockfrost/blockfrost-platform/actions/runs/12053888754?pr=93).

# Important Changes Introduced

`cargo test` now only has only 10 minutes to finish. But it's instant in normal operation, so that should be fine.