### PR TITLE
chore: trigger `nix-ci.yml` from `main`, not `master`

### DIFF
--- a/.github/workflows/nix-ci.yaml
+++ b/.github/workflows/nix-ci.yaml
@@ -2,7 +2,7 @@ name: Nix
 on:
   push:
     branches:
-      - master
+      - main
 jobs:
   build:
     name: CI


### PR DESCRIPTION
# Context

We missed that when renaming the main branch a few days ago.

# Important Changes Introduced

`nix-ci.yml` will run again.