### PR TITLE
fix: x86-64 Darwin CI; remove left-over FIXMEs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -64,7 +64,7 @@
             })
           ];
           programs.rustfmt.enable = true;
-          programs.yamlfmt.enable = true;
+          programs.yamlfmt.enable = pkgs.system != "x86_64-darwin"; # a treefmt-nix+yamlfmt bug on Intel Macs
           programs.taplo.enable = true; # TOML
           programs.shfmt.enable = true;
         };

--- a/src/cbor/fallback_decoder.rs
+++ b/src/cbor/fallback_decoder.rs
@@ -165,8 +165,6 @@ impl FallbackDecoder {
         last_unfulfilled_request: &mut Option<FDRequest>,
         current_child_pid: &Arc<AtomicU32>,
     ) -> Result<(), String> {
-        // FIXME: _find_ the exe_path
-        // FIXME: make a release with LineBuffering
         let exe_path = Self::locate_child_binary().unwrap_or(CHILD_EXE_NAME.to_string());
 
         let mut child = proc::Command::new(exe_path)


### PR DESCRIPTION
# Context

Currently on `main`, the [`x86_64-darwin` run is failing](https://github.com/blockfrost/blockfrost-platform/actions/runs/12085684681/job/33703419363):

```
Initialized empty Git repository in /private/tmp/nix-build-treefmt-check.drv-0/project/.git/
treefmt v2.1.02024/11/29 13:49:41 INFO using config file: /nix/store/vpf1yg6dcq9765d0qbq94mbq32kipgzw-treefmt.toml
Error: failed to create composite formatter: failed to initialise formatter yamlfmt: formatter command not found in PATH
```

I was able to reproduce locally, but didn't investigate why. Probably not worth the time, considering we're running 2 other `yamlfmt`s – on `x86_64-linux` and `aarch64-darwin`, and they work there.

IMO, let's just disable `yamlfmt` on `x86_64-darwin`, and call it a day.

I also removed 2 `FIXME`s that I missed in #93 – sorry! :face_with_peeking_eye: 

# Important Changes Introduced

_none_