### PR TITLE
fix: intra-doc links, and other `rustdoc` errors

### DIFF
--- a/src/cbor/haskell_types.rs
+++ b/src/cbor/haskell_types.rs
@@ -16,7 +16,7 @@ use std::fmt::Display;
 
 /// This file contains the types that are mapped from the Haskell codebase.
 /// The main reason these mappings exist is to mimick the error responses from the cardano-submit-api
-/// and generate identical responses to the Blockfrost.io /tx/submit API (https://docs.blockfrost.io/#tag/cardano--transactions/POST/tx/submit)
+/// and generate identical responses to the [Blockfrost.io `/tx/submit` API](https://docs.blockfrost.io/#tag/cardano--transactions/POST/tx/submit).
 ///
 /// To mimick, we need to:
 /// - Decode the CBOR error reasons (pallas doesn't do it) from the cardano-node
@@ -27,6 +27,7 @@ use std::fmt::Display;
 /// - Types that are used to generate the JSON response structure
 ///
 /// Here is an example response from the cardano-submit-api:
+/// ```text
 /// curl --header "Content-Type: application/cbor" -X POST http://localhost:8090/api/submit/tx --data-binary @tx.bin
 /// {
 ///     "contents": {
@@ -45,8 +46,10 @@ use std::fmt::Display;
 ///     },
 ///     "tag": "TxSubmitFail"
 ///   }
+/// ```
 ///
 /// Here is an example CBOR error reason from the cardano-node:
+/// ```text
 /// [2,
 ///     [
 ///         [6,
@@ -65,20 +68,21 @@ use std::fmt::Display;
 ///         ]
 ///     ]
 /// ]
+/// ```
 ///
 /// TxValidationError is the most outer type that is decoded from the CBOR error reason.
 /// Than, it is wrapped in TxValidationErrorInCardanoMode and TxCmdTxSubmitValidationError to generate the JSON response.
 ///
 /// Type examples:
-/// https://github.com/IntersectMBO/ouroboros-consensus/blob/82c5ebf7c9f902b7250144445f45083c1c13929e/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Eras.hs#L334
-/// https://github.com/IntersectMBO/cardano-node-emulator/blob/ba5c4910a958bbccb38399f6a871459e46701a93/cardano-node-emulator/src/Cardano/Node/Emulator/Internal/Node/Validation.hs#L255
-/// https://github.com/IntersectMBO/cardano-node/blob/master/cardano-testnet/test/cardano-testnet-test/files/golden/tx.failed.response.json.golden
+/// * <https://github.com/IntersectMBO/ouroboros-consensus/blob/82c5ebf7c9f902b7250144445f45083c1c13929e/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Eras.hs#L334>
+/// * <https://github.com/IntersectMBO/cardano-node-emulator/blob/ba5c4910a958bbccb38399f6a871459e46701a93/cardano-node-emulator/src/Cardano/Node/Emulator/Internal/Node/Validation.hs#L255>
+/// * <https://github.com/IntersectMBO/cardano-node/blob/master/cardano-testnet/test/cardano-testnet-test/files/golden/tx.failed.response.json.golden>
 ///
 /// Haskell references to the types are commented next to them.
 /// Here are some more type references:
-/// https://github.com/IntersectMBO/cardano-ledger/blob/78b20b6301b2703aa1fe1806ae3c129846708a10/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs#L737
-/// https://github.com/IntersectMBO/cardano-ledger/blob/master/eras/mary/impl/src/Cardano/Ledger/Mary/Value.hs
-/// https://github.com/IntersectMBO/cardano-ledger/blob/master/libs/cardano-ledger-core/src/Cardano/Ledger/Coin.hs
+/// * <https://github.com/IntersectMBO/cardano-ledger/blob/78b20b6301b2703aa1fe1806ae3c129846708a10/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs#L737>
+/// * <https://github.com/IntersectMBO/cardano-ledger/blob/master/eras/mary/impl/src/Cardano/Ledger/Mary/Value.hs>
+/// * <https://github.com/IntersectMBO/cardano-ledger/blob/master/libs/cardano-ledger-core/src/Cardano/Ledger/Coin.hs>
 
 /*
 ** cardano-node CBOR types

--- a/src/node/connection.rs
+++ b/src/node/connection.rs
@@ -13,8 +13,8 @@ use tracing::warn;
 /// this, you won’t get any deadlocks, inconsistencies, etc.
 pub struct NodeClient {
     /// Note: this is an [`Option`] *only* to satisfy the borrow checker. It’s
-    /// *always* [`Some`]. See [`NodeConnPoolManager::recycle`] for an
-    /// explanation.
+    /// *always* [`Some`]. See [`<super::pool_manager::NodePoolManager as
+    /// deadpool::managed::Manager>>::recycle`] for an explanation.
     pub(in crate::node) client: Option<NodeClientFacade>,
     pub(in crate::node) fallback_decoder: FallbackDecoder,
 }

--- a/src/node/pool.rs
+++ b/src/node/pool.rs
@@ -2,7 +2,7 @@ use super::pool_manager::NodePoolManager;
 use crate::{cbor::fallback_decoder::FallbackDecoder, cli::Config, AppError};
 use deadpool::managed::{Object, Pool};
 
-/// This represents a pool of Node2Client connections to a single `cardano-node`.
+/// This represents a pool of `NodeToClient` connections to a single `cardano-node`.
 ///
 /// It can be safely cloned to multiple threads, while still sharing the same
 /// set of underlying connections to the node.
@@ -12,7 +12,7 @@ pub struct NodePool {
 }
 
 impl NodePool {
-    /// Creates a new pool of [`NodeConn`] connections.
+    /// Creates a new pool of [`super::connection::NodeClient`] connections.
     pub fn new(config: &Config, fallback_decoder: FallbackDecoder) -> Result<Self, AppError> {
         let manager = NodePoolManager {
             network_magic: config.network_magic,
@@ -27,7 +27,7 @@ impl NodePool {
         Ok(Self { pool_manager })
     }
 
-    /// Borrows a single [`NodeConn`] connection from the pool.
+    /// Borrows a single [`super::connection::NodeClient`] connection from the pool.
     pub async fn get(&self) -> Result<Object<NodePoolManager>, AppError> {
         self.pool_manager
             .get()

--- a/src/node/pool_manager.rs
+++ b/src/node/pool_manager.rs
@@ -44,10 +44,10 @@ impl Manager for NodePoolManager {
 
     /// Pallas decided to make the
     /// [`pallas_network::facades::NodeClient::abort`] take ownership of `self`.
-    /// That’s why we need our [`Node::client`] to be an [`Option`],
-    /// because in here we only get a mutable reference. If the connection is
-    /// broken, we have to call `abort`, because it joins certain multiplexer
-    /// threads. Otherwise, it’s a resource leak.
+    /// That’s why we need our `NodeClient::client` to be an [`Option`], because
+    /// in here we only get a mutable reference. If the connection is broken, we
+    /// have to call [`pallas_network::facades::NodeClient::abort`], because it
+    /// joins certain multiplexer threads. Otherwise, it’s a resource leak.
     async fn recycle(&self, node: &mut NodeClient, metrics: &Metrics) -> RecycleResult<AppError> {
         // Check if the connection is still viable
         match node.ping().await {

--- a/src/node/transactions.rs
+++ b/src/node/transactions.rs
@@ -13,10 +13,10 @@ use tracing::{info, warn};
 impl NodeClient {
     /// Submits a transaction to the connected Cardano node.
     /// This API meant to be fully compatible with cardano-submit-api.
-    /// Should return Http 200 if the transaction was accepted by the node.
-    /// If the transaction was rejected, should return Http 400 with a JSON body.
-    /// swagger: https://github.com/IntersectMBO/cardano-node/blob/6e969c6bcc0f07bd1a69f4d76b85d6fa9371a90b/cardano-submit-api/swagger.yaml#L52
-    /// Haskell code:  https://github.com/IntersectMBO/cardano-node/blob/6e969c6bcc0f07bd1a69f4d76b85d6fa9371a90b/cardano-submit-api/src/Cardano/TxSubmit/Web.hs#L158
+    /// Should return HTTP 200 if the transaction was accepted by the node.
+    /// If the transaction was rejected, should return HTTP 400 with a JSON body:
+    /// * Swagger: <https://github.com/IntersectMBO/cardano-node/blob/6e969c6bcc0f07bd1a69f4d76b85d6fa9371a90b/cardano-submit-api/swagger.yaml#L52>
+    /// * Haskell code: <https://github.com/IntersectMBO/cardano-node/blob/6e969c6bcc0f07bd1a69f4d76b85d6fa9371a90b/cardano-submit-api/src/Cardano/TxSubmit/Web.hs#L158>
     pub async fn submit_transaction(&mut self, tx: String) -> Result<String, BlockfrostError> {
         let tx = hex::decode(tx).map_err(|e| BlockfrostError::custom_400(e.to_string()))?;
         let txid = hex::encode(Hasher::<256>::hash_cbor(&tx));


### PR DESCRIPTION
# Context

I noticed they were broken after past refactorings.

# Important Changes Introduced

None.