### PR TITLE
chore: fix docker-compose cardano node init script

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   init-node:
-    image: ghcr.io/input-output-hk/mithril-client:2442.0-0d4d6bc
+    image: ghcr.io/input-output-hk/mithril-client:2450.0-c6c7eba
     entrypoint: /app/bin/entrypoint.sh
     user: "${UID}:${GID}"
     environment:


### PR DESCRIPTION
# Context
Cardano node init was crashing, it seems that there were some incompatible changes between mithril client version and snapshots. Update fixed it

# Important Changes Introduced
