### PR TITLE
chore: build the OCI image on every push, but publish only from `main`

### DIFF
--- a/.github/workflows/oci-image.yaml
+++ b/.github/workflows/oci-image.yaml
@@ -1,10 +1,8 @@
-name: Publish OCI
+name: OCI
 on:
   push:
-    branches:
-      - main
 jobs:
-  publish:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout repository
@@ -15,7 +13,10 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: 🚀 Build and push the image
+      - name: 🚀 Build the image
         run: |
           docker compose build
+      - name: 📤 Push the image
+        if: github.ref == 'refs/heads/main'
+        run: |
           docker push ghcr.io/blockfrost/blockfrost-platform:latest


### PR DESCRIPTION
# Context

We missed that the OCI image stopped building. It was referencing `:latest` of its dependency, and it got broken by upstream.

Found by @mmahut in this [Slack thread](https://input-output-rnd.slack.com/archives/C07FD0DNEMQ/p1736714894095699).

Fixed by @gytis-ivaskevicius in PR #105.

@mmahut suggests that we build the OCI image on each commit, but only _publish_ from `main`, and this PR implements that.

# Important Changes Introduced

_none_