### PR TITLE
chore: add `nixConfig` with IOG’s binary cache to the flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -96,5 +96,11 @@
             ++ lib.collect lib.isDerivation inputs.self.hydraJobs.devshell;
         };
       };
+
+      flake.nixConfig = {
+        extra-substituters = ["https://cache.iog.io"];
+        extra-trusted-public-keys = ["hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="];
+        allow-import-from-derivation = "true";
+      };
     });
 }


### PR DESCRIPTION
# Context

Follow-up to: PR #110.

The user has to be in `trusted-users` for this to work, but it's also useful as a documentation/discovery tool.

As requested by @gytis-ivaskevicius.

# Important Changes Introduced

_none_