### PR TITLE
chore: run `treefmt` on `main`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,5 +26,3 @@ guide](https://platform.blockfrost.io/getting-started).
 ## Join our community
 
 [Join us on Discord](https://discord.gg/inputoutput).
-
-

--- a/docs/src/pages/_meta.js
+++ b/docs/src/pages/_meta.js
@@ -1,16 +1,16 @@
 let config = {
   index: "Introduction",
   "---": {
-    type: "separator"
+    type: "separator",
   },
   "get-started": "Getting started",
-  "installation": "Installation",
-  "usage": "Usage",
-  "options": "Advanced options",
+  installation: "Installation",
+  usage: "Usage",
+  options: "Advanced options",
   "---": {
-    type: "separator"
+    type: "separator",
   },
-  "faq": "FAQ",
+  faq: "FAQ",
 };
 
 export default config;

--- a/docs/src/pages/faq.mdx
+++ b/docs/src/pages/faq.mdx
@@ -1,7 +1,8 @@
-import { Callout } from 'nextra/components'
+import { Callout } from "nextra/components";
 
 # Frequently asked questions
 
 <Callout>
-Cannot find your question listed here and it is missing from the documentation? Please contact us on Discord.
+  Cannot find your question listed here and it is missing from the
+  documentation? Please contact us on Discord.
 </Callout>

--- a/docs/src/pages/get-started.mdx
+++ b/docs/src/pages/get-started.mdx
@@ -1,8 +1,9 @@
-import { Callout, Table } from 'nextra/components'
+import { Callout, Table } from "nextra/components";
 
 ## Getting started
 
 Before we start, there are a couple of prerequisites you will need:
+
 - ✅ A running mainnet (production) instance of cardano-node.
   - If you are an SPO, we recommend running this on one of your relays.
   - Follow [the official Cardano node documentation](https://developers.cardano.org/docs/get-started/cardano-node/installing-cardano-node) to install and run your instance otherwise.
@@ -10,7 +11,8 @@ Before we start, there are a couple of prerequisites you will need:
 - ✅ A secret for your Icebreaker account (also provided by the Blockfrost team).
 
 <Callout>
-If you want to run the backend as your own instance, use the solitary mode (`--solitary` command line option) to avoid joining the Blockfrost cluster.
+  If you want to run the backend as your own instance, use the solitary mode
+  (`--solitary` command line option) to avoid joining the Blockfrost cluster.
 </Callout>
 
 Do you have everything needed? Let's move to the installation.

--- a/docs/src/pages/index.mdx
+++ b/docs/src/pages/index.mdx
@@ -7,4 +7,3 @@ It is a replacement for the legacy open source [Blockfrost backend](https://gith
 ## Decentraliation
 
 Although it can be run in a solitary mode, it is primarly designed to join a cluster of other Blockfrost platforms to serve the data to the users of the production Blockfrost.io API instance. Learn more about our [Icebreakers program](/icebreakers).
-

--- a/docs/src/pages/installation/_meta.js
+++ b/docs/src/pages/installation/_meta.js
@@ -1,7 +1,7 @@
 let config = {
-    "source": "From source code",
-    "nix": "Using Nix",
-    "docker": "Using Docker",
+  source: "From source code",
+  nix: "Using Nix",
+  docker: "Using Docker",
 };
 
 export default config;

--- a/docs/src/pages/installation/docker.md
+++ b/docs/src/pages/installation/docker.md
@@ -5,17 +5,17 @@ To build the Docker image containing the project binary, in the root folder of t
 ```console
 # Clone the repository
 git clone https://github.com/blockfrost/blockfrost-platform
- 
+
 # Navigate to the project directory
 cd blockfrost-platform
- 
+
 # To build the latest main version (experimental)
 git checkout main
- 
+
 # To build a release version (recommended)
 # NOTE: this option will be available after the first release
-# git checkout v0.1 
- 
+# git checkout v0.1
+
 # Build the docker image
 docker build -t blockfrost-platform .
 ```

--- a/docs/src/pages/installation/nix.md
+++ b/docs/src/pages/installation/nix.md
@@ -14,7 +14,7 @@ git checkout main
 
 # To build a release version (recommended)
 # NOTE: this option will be available after the first release
-# git checkout v0.1 
+# git checkout v0.1
 
 # Build the project using nix
 nix build

--- a/docs/src/pages/installation/source.mdx
+++ b/docs/src/pages/installation/source.mdx
@@ -1,4 +1,4 @@
-import { Tabs, Tab } from "nextra/components"
+import { Tabs, Tab } from "nextra/components";
 
 ## Building from the source code
 
@@ -19,13 +19,14 @@ First, we need to install dependencies on your system.
     apt install git rustup libssl-dev pkg-config
     ```
 
-   After installing `rustup`, you need to switch to latest stable Rust.
-   ```shell
-   rustup default stable
-   ```
+After installing `rustup`, you need to switch to latest stable Rust.
+
+```shell
+rustup default stable
+```
+
   </Tabs.Tab>
 </Tabs>
-
 
 ```bash
 # Clone the repository
@@ -39,7 +40,7 @@ git checkout main
 
 # To build a release version (recommended)
 # NOTE: this option will be available after the first release
-# git checkout v0.1 
+# git checkout v0.1
 
 # Build the project
 cargo build --release

--- a/docs/src/pages/usage/_meta.js
+++ b/docs/src/pages/usage/_meta.js
@@ -1,6 +1,6 @@
 let config = {
-    "cli": "Running the platform",
-    "docker": "Using Docker",
+  cli: "Running the platform",
+  docker: "Using Docker",
 };
 
 export default config;

--- a/docs/src/pages/usage/cli.mdx
+++ b/docs/src/pages/usage/cli.mdx
@@ -1,4 +1,4 @@
-import { Callout, Table } from 'nextra/components'
+import { Callout, Table } from "nextra/components";
 
 # Running the platform from your command line
 
@@ -12,7 +12,8 @@ blockfrost-platform [OPTIONS] --network <NETWORK> \
 ```
 
 <Callout>
-For the full list of the command line options, run `blockfrost-platform --help`.
+  For the full list of the command line options, run `blockfrost-platform
+  --help`.
 </Callout>
 
 # Setting up systemd for your instance
@@ -39,7 +40,6 @@ REWARD_ADDR=addr1_rest_of_my_reward_address_that_holds_my_nft_license_provided_b
                                    --secret $SECRET \
                                    --reward-address $REWARD_ADDR
 ```
-
 
 Create a new `blockfrost-platform.service` file and add this to it:
 

--- a/docs/src/pages/usage/docker.mdx
+++ b/docs/src/pages/usage/docker.mdx
@@ -1,10 +1,9 @@
-import { Callout, Table } from 'nextra/components'
+import { Callout, Table } from "nextra/components";
 
 # Running the platform using Docker
 
 Once you have the Docker image on your machine from the previous installation
 section, you can run it using:
-
 
 ```bash
 docker run -it --init --rm \
@@ -17,13 +16,14 @@ docker run -it --init --rm \
 ```
 
 <Callout>
-Make sure your Cardano node socket is attached as a volume, i.e. `-v /home/user/my_node.socket:/var/run/node.socket`.
+  Make sure your Cardano node socket is attached as a volume, i.e. `-v
+  /home/user/my_node.socket:/var/run/node.socket`.
 </Callout>
 <Callout>
-If you don't specify an IP address (i.e., `-p 3000:3000` instead 
-of `-p 127.0.0.1:3000:3000`) when publishing a container's ports, Docker
-publishes the port on all interfaces (address `0.0.0.0`) by default. These
-ports are externally accessible.
+  If you don't specify an IP address (i.e., `-p 3000:3000` instead of `-p
+  127.0.0.1:3000:3000`) when publishing a container's ports, Docker publishes
+  the port on all interfaces (address `0.0.0.0`) by default. These ports are
+  externally accessible.
 </Callout>
 
 # Running the entire cluster using Docker compose
@@ -41,11 +41,12 @@ NETWORK=preview docker compose -p mainnet --profile solitary up --build -d
 NETWORK=preview SECRET=my-secret REWARD_ADDRESS=my-reward-address docker compose -p mainnet up --build -d
 
 # Watch the build
-docker compose watch 
+docker compose watch
 ```
 
 Please note:
-* If you want to avoid running it in the background, omit the `-d` flag.
-* If you want to skip building, omit the `--build` flag.
-* Setting `-p mainnet` to the desired network will let you run on different networks without messing your node db. You can omit it if you plan to run on the same network always.
-* You don't need to provide `--node-socket-path` since it is  already handled inside `docker-compose.yml`.
+
+- If you want to avoid running it in the background, omit the `-d` flag.
+- If you want to skip building, omit the `--build` flag.
+- Setting `-p mainnet` to the desired network will let you run on different networks without messing your node db. You can omit it if you plan to run on the same network always.
+- You don't need to provide `--node-socket-path` since it is already handled inside `docker-compose.yml`.

--- a/docs/theme.config.tsx
+++ b/docs/theme.config.tsx
@@ -3,7 +3,7 @@ import { DocsThemeConfig } from "nextra-theme-docs";
 
 const config: DocsThemeConfig = {
   logo: () => (
-    <img src='https://blockfrost.dev/img/logo.svg' style={{ "height": "30px" }} />
+    <img src="https://blockfrost.dev/img/logo.svg" style={{ height: "30px" }} />
   ),
   project: {
     link: "https://github.com/blockfrost/blockfrost-platform",
@@ -11,7 +11,8 @@ const config: DocsThemeConfig = {
   chat: {
     link: "https://discord.gg/inputoutput",
   },
-  docsRepositoryBase: "https://github.com/blockfrost/blockfrost-platform/tree/main/docs",
+  docsRepositoryBase:
+    "https://github.com/blockfrost/blockfrost-platform/tree/main/docs",
   footer: {},
 };
 


### PR DESCRIPTION
# Context

Checks are failing on `main`, because `treefmt` is changing the worktree.

See https://ci.iog.io/build/6482480/nixlog/1.

#103 didn’t have Hydra checks merged into it, so it slipped through.

# Important Changes Introduced

_none_
