### PR TITLE
chore: run Cargo checks on the Hydra CI

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,17 @@
+[advisories]
+ignore = [
+  "RUSTSEC-2022-0004", # Solution:  No fixed upgrade is available!
+  "RUSTSEC-2024-0421", # FIXME: upgrade to idna >=1.0.0 (transitive dependency of `url`)
+]
+informational_warnings = ["unmaintained"]
+severity_threshold = "low"
+
+[output]
+deny = ["unmaintained"]
+format = "terminal"
+quiet = false
+show_tree = true
+
+[yanked]
+enabled = true
+update_index = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -948,9 +948,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
  "foldhash",
 ]
@@ -1169,7 +1169,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.0",
+ "hashbrown 0.15.2",
  "serde",
 ]
 
@@ -1333,7 +1333,7 @@ checksum = "dbd4884b1dd24f7d6628274a2f5ae22465c337c5ba065ec9b6edccddf8acc673"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
- "hashbrown 0.15.0",
+ "hashbrown 0.15.2",
  "metrics",
  "quanta",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "blockfrost-platform"
 version = "0.0.1"
+license = "Apache-2.0"
 edition = "2021"
 build = "build.rs"
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,13 @@
+[licenses]
+# See <https://spdx.org/licenses/> for list of possible licenses
+allow = [
+  "Apache-2.0",
+  "BSD-3-Clause",
+  "CC0-1.0",
+  "MIT",
+  "Unicode-3.0",
+  "MPL-2.0",
+  "BlueOak-1.0.0",
+  "Zlib",
+]
+confidence-threshold = 0.8

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "advisory-db": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1737246984,
+        "narHash": "sha256-cjWzMwqej9zVoFGV5NkefOspMDJJ+gN3+zkFZcBBAkc=",
+        "owner": "rustsec",
+        "repo": "advisory-db",
+        "rev": "cfd49ce116f12c856a3f3c065d041fd0dd7169dc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rustsec",
+        "repo": "advisory-db",
+        "type": "github"
+      }
+    },
     "cardano-node": {
       "flake": false,
       "locked": {
@@ -133,6 +149,7 @@
     },
     "root": {
       "inputs": {
+        "advisory-db": "advisory-db",
         "cardano-node": "cardano-node",
         "cardano-playground": "cardano-playground",
         "crane": "crane",

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,8 @@
     devshell.inputs.nixpkgs.follows = "nixpkgs";
     cardano-playground.url = "github:input-output-hk/cardano-playground/b4f47fd78beec0ea1ed880d6f0b794919e0c0463";
     cardano-playground.flake = false; # otherwise, +9k dependencies in flake.lock…
+    advisory-db.url = "github:rustsec/advisory-db";
+    advisory-db.flake = false;
   };
 
   outputs = inputs: let
@@ -45,10 +47,10 @@
         system,
         pkgs,
         ...
-      }: {
-        packages = let
-          internal = inputs.self.internal.${system};
-        in
+      }: let
+        internal = inputs.self.internal.${system};
+      in {
+        packages =
           {
             default = internal.package;
             inherit (internal) tx-build cardano-address testgen-hs;
@@ -58,6 +60,8 @@
           });
 
         devshells.default = import ./nix/devshells.nix {inherit inputs;};
+
+        checks = internal.cargoChecks;
 
         treefmt = {pkgs, ...}: {
           projectRootFile = "flake.nix";


### PR DESCRIPTION
# Context

Currently we’re not running these anywhere in CI:
* `cargo clippy` – a general linter,
* `cargo doc` – for checking intra-doc links,
* `cargo audit` – checking for known CVEs in the RustSec Advisory Database,
* `cargo deny` – checking licensing compatibility.

I also moved `cargo test` from the package to a separate check that is run with `cargo nextest`, which has much clearer and more informative output that the built-in `cargo test`.

# Important Changes Introduced

_none_
