### PR TITLE
fixing two typos

### DIFF
--- a/docs/src/pages/index.mdx
+++ b/docs/src/pages/index.mdx
@@ -4,6 +4,6 @@ Blockfrost platform is a software that services a developer-friendly JSON API fo
 
 It is a replacement for the legacy open source [Blockfrost backend](https://github.com/blockfrost/blockfrost-backend-ryo/) and is targeted at SPOs and other Cardano node operators that want to serve it on their nodes.
 
-## Decentraliation
+## Decentralization
 
-Although it can be run in a solitary mode, it is primarly designed to join a cluster of other Blockfrost platforms to serve the data to the users of the production Blockfrost.io API instance. Learn more about our [Icebreakers program](/icebreakers).
+Although it can be run in a solitary mode, it is primarily designed to join a cluster of other Blockfrost platforms to serve the data to the users of the production Blockfrost.io API instance. Learn more about our [Icebreakers program](/icebreakers).


### PR DESCRIPTION
On the first page, fixing these two typos: 

Decentraliation -> Decentralization
primarly -> primarily
