### PR TITLE
Twelf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -335,6 +335,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing-test",
+ "twelf",
  "uuid",
  "walkdir",
  "zip",
@@ -465,10 +466,10 @@ version = "4.5.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -482,6 +483,18 @@ name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
+name = "config-derive"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c547326a30684f853601fb959cc8ecbd0d72abbdd27ba634850a918fa29afc4"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "constant_time_eq"
@@ -606,7 +619,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -617,7 +630,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -703,7 +716,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -734,6 +747,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "envy"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f47e0157f2cb54f5ae1bd371b30a2ae4311e1c028f575cd4e81de7353215965"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -864,7 +886,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -978,6 +1000,12 @@ checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
  "foldhash",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -1280,7 +1308,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1531,7 +1559,7 @@ checksum = "bd2209fff77f705b00c737016a48e73733d7fbccb8b007194db148f03561fb70"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1689,7 +1717,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1959,7 +1987,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6eea3058763d6e656105d1403cb04e0a41b7bbac6362d413e7c33be0c32279c9"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "itertools",
  "prost",
  "prost-types",
@@ -2025,7 +2053,7 @@ checksum = "d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2084,7 +2112,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2121,7 +2149,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0f3e5beed80eb580c68e2c600937ac2c4eedabdfd5ef1e5b7ea4f3fba84497b"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "itertools",
  "log",
  "multimap",
@@ -2131,7 +2159,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn",
+ "syn 2.0.96",
  "tempfile",
 ]
 
@@ -2145,7 +2173,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2411,7 +2439,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn",
+ "syn 2.0.96",
  "unicode-ident",
 ]
 
@@ -2672,7 +2700,7 @@ checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2745,7 +2773,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2777,6 +2805,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "shellexpand"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da03fa3b94cc19e3ebfc88c4229c49d8f08cdbd1228870a45f0ffdf84988e14b"
+dependencies = [
+ "dirs",
 ]
 
 [[package]]
@@ -2851,6 +2888,17 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
@@ -2877,7 +2925,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2966,7 +3014,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2977,7 +3025,7 @@ checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3071,7 +3119,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3235,7 +3283,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3295,7 +3343,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3303,6 +3351,22 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "twelf"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16de46d08a9d3a25e0a65bb70090797b970bd1e95d72872567ba8d02c0b03bdf"
+dependencies = [
+ "clap",
+ "config-derive",
+ "envy",
+ "log",
+ "serde",
+ "serde_json",
+ "shellexpand",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "typenum"
@@ -3474,7 +3538,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.96",
  "wasm-bindgen-shared",
 ]
 
@@ -3509,7 +3573,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.96",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3613,7 +3677,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3624,7 +3688,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3872,7 +3936,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.96",
  "synstructure",
 ]
 
@@ -3894,7 +3958,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3914,7 +3978,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.96",
  "synstructure",
 ]
 
@@ -3943,7 +4007,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.96",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ sysinfo = "0.33.1"
 walkdir = "2.5.0"
 dotenvy = "0.15.7"
 uuid = { version = "1.10.0", features = ["v4"] }
+twelf = "0.15.0"
 
 [dev-dependencies]
 tracing-test = "0.2.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ sysinfo = "0.33.1"
 walkdir = "2.5.0"
 dotenvy = "0.15.7"
 uuid = { version = "1.10.0", features = ["v4"] }
-twelf = "0.15.0"
+twelf = {version = "0.15.0", features = ["clap"]}
 
 [dev-dependencies]
 tracing-test = "0.2.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ sysinfo = "0.33.1"
 walkdir = "2.5.0"
 dotenvy = "0.15.7"
 uuid = { version = "1.10.0", features = ["v4"] }
-twelf = {version = "0.15.0", features = ["clap"]}
+twelf = { version = "0.15.0", features = ["clap"] }
 
 [dev-dependencies]
 tracing-test = "0.2.5"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -57,8 +57,8 @@ impl Args {
     pub fn init() -> Result<Config, AppError> {
         let matches = Self::command().get_matches();
         let arguments = Self::with_layers(&[
-            Layer::Env(Some(String::from("BLOCKFROST_"))),
             Layer::Clap(matches),
+            Layer::Env(Some(String::from("BLOCKFROST_"))),
         ])
         .map_err(|it| AppError::Server(it.to_string()))?;
 
@@ -67,6 +67,7 @@ impl Args {
 }
 
 #[derive(Debug, Clone, ValueEnum, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum Mode {
     Compact,
     Light,
@@ -74,6 +75,7 @@ pub enum Mode {
 }
 
 #[derive(Debug, Clone, ValueEnum, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum Network {
     Mainnet,
     Preprod,
@@ -81,6 +83,7 @@ pub enum Network {
 }
 
 #[derive(Debug, Clone, ValueEnum, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum LogLevel {
     Debug,
     Info,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -116,7 +116,7 @@ impl Config {
         let icebreakers_config = if !args.solitary {
             let reward_address = args
                 .reward_address
-                .ok_or(AppError::Server("--rewards-address must be set".into()))?;
+                .ok_or(AppError::Server("--reward-address must be set".into()))?;
             let secret = args
                 .secret
                 .ok_or(AppError::Server("--secret must be set".into()))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,30 +2,24 @@ use axum::extract::Request;
 use axum::ServiceExt;
 use blockfrost_platform::{
     background_tasks::node_health_check_task,
-    cli::{Args, Config},
-    cbor::fallback_decoder::FallbackDecoder,
     cli::Args,
-    errors::{AppError, BlockfrostError},
-    icebreakers_api::IcebreakersAPI,
+    errors::AppError,
     logging::setup_tracing,
     server::build,
-    AppError,
 };
-use clap::Parser;
-use std::sync::Arc;
+use dotenvy::dotenv;
 use tokio::{signal, sync::oneshot};
-use tower::ServiceBuilder;
-use tower_http::normalize_path::NormalizePathLayer;
 use tracing::info;
 
 #[tokio::main]
 async fn main() -> Result<(), AppError> {
+    dotenv().ok();
     let config = Args::init()?;
 
     // Logging
     setup_tracing(config.log_level);
 
-    let (app, node_conn_pool, icebreakers_api, api_prefix) = build(config.clone()).await?;
+    let (app, node_conn_pool, icebreakers_api, api_prefix) = build(config.clone().into()).await?;
     let address = format!("{}:{}", config.server_address, config.server_port);
     let listener = tokio::net::TcpListener::bind(&address).await?;
     let (ready_tx, ready_rx) = oneshot::channel();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,7 @@
 use axum::extract::Request;
 use axum::ServiceExt;
 use blockfrost_platform::{
-    background_tasks::node_health_check_task,
-    cli::Args,
-    errors::AppError,
-    logging::setup_tracing,
+    background_tasks::node_health_check_task, cli::Args, errors::AppError, logging::setup_tracing,
     server::build,
 };
 use dotenvy::dotenv;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,10 @@ use axum::ServiceExt;
 use blockfrost_platform::{
     background_tasks::node_health_check_task,
     cli::{Args, Config},
+    cbor::fallback_decoder::FallbackDecoder,
+    cli::Args,
+    errors::{AppError, BlockfrostError},
+    icebreakers_api::IcebreakersAPI,
     logging::setup_tracing,
     server::build,
     AppError,
@@ -10,13 +14,13 @@ use blockfrost_platform::{
 use clap::Parser;
 use std::sync::Arc;
 use tokio::{signal, sync::oneshot};
+use tower::ServiceBuilder;
+use tower_http::normalize_path::NormalizePathLayer;
 use tracing::info;
 
 #[tokio::main]
 async fn main() -> Result<(), AppError> {
-    // CLI
-    let arguments = Args::parse();
-    let config = Arc::new(Config::from_args(arguments)?);
+    let config = Args::init()?;
 
     // Logging
     setup_tracing(config.log_level);


### PR DESCRIPTION
# Context

Exact reimplementation of [this PR](https://github.com/blockfrost/blockfrost-platform/pull/125/files) using twelf

It still has some issues:
```
✦ ~/iohk/blockfrost-platform twelf* 9s
blockfrost-platform-devshell-env ❯ export BLOCKFROST_NETWORK=mainnet

✦ ~/iohk/blockfrost-platform twelf*
blockfrost-platform-devshell-env ❯ cargo run -- --node-socket-path asdf --secret 12345678 --reward-address asdf --network preview
   Compiling blockfrost-platform v0.0.1 (/home/gytis/iohk/blockfrost-platform)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 4.14s
warning: the following packages contain code that will be rejected by a future version of Rust: cbor v0.4.1
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
     Running `target/debug/blockfrost-platform --node-socket-path asdf --secret 12345678 --reward-address asdf --network preview`
[src/cli.rs:63:27] arguments = Args {
    server_address: "0.0.0.0",
    server_port: 3000,
    network: Mainnet,
    log_level: Info,
    node_socket_path: "asdf",
    mode: Compact,
    solitary: false,
    secret: Some(
        "12345678",
    ),
    reward_address: Some(
        "asdf",
    ),
}
2025-01-27T12:22:55.666281Z  INFO Using /home/gytis/iohk/blockfrost-platform/target/testgen-hs/extracted/testgen-hs/testgen-hs as a fallback CBOR error decoder
2025-01-27T12:22:55.667474Z  INFO Connecting to Icebreakers API...
2025-01-27T12:22:55.679810Z  INFO Registering with icebreakers api...
2025-01-27T12:22:55.736621Z ERROR FallbackDecoder: will restart in 1s because of a subprocess error: Err("request channel closed, won’t happen")
Error: Registration("Failed to register with Icebreakers API: Provided fields are not valid details: Validation error: missing field `api_prefix` at line 1 column 74")

✦ ~/iohk/blockfrost-platform twelf*
blockfrost-platform-devshell-env ❯ # Mainnet takes priority...

✦ ~/iohk/blockfrost-platform twelf*
blockfrost-platform-devshell-env ❯ cargo run -- --node-socket-path asdf --secret 12345678 --reward-address asdf
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.14s
warning: the following packages contain code that will be rejected by a future version of Rust: cbor v0.4.1
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
     Running `target/debug/blockfrost-platform --node-socket-path asdf --secret 12345678 --reward-address asdf`
error: the following required arguments were not provided:
  --network <NETWORK>

Usage: blockfrost-platform --network <NETWORK> --node-socket-path <NODE_SOCKET_PATH> --secret <SECRET> --reward-address <REWARD_ADDRESS>

For more information, try '--help'.

✦ ~/iohk/blockfrost-platform twelf*
blockfrost-platform-devshell-env ❯ # And still network is a requried arg
```
I consider these issues a bugs, and ill fix them now