### PR TITLE
chore: tweak how `testgen-hs` is found in runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ result-*
 
 /cardano-node-configs
 
+testgen-hs
+testgen-hs.exe
+
 # Ignore IDE specific files
 # Visual Studio Code
 .vscode/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,7 +337,6 @@ dependencies = [
  "tracing-test",
  "twelf",
  "uuid",
- "walkdir",
  "zip",
 ]
 
@@ -2529,15 +2528,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3492,16 +3482,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
-]
-
-[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3612,15 +3592,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
-dependencies = [
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ chrono = "0.4"
 deadpool = "0.12.1"
 serde_with = "3.12.0"
 sysinfo = "0.33.1"
-walkdir = "2.5.0"
 dotenvy = "0.15.7"
 uuid = { version = "1.10.0", features = ["v4"] }
 twelf = { version = "0.15.0", features = ["clap"] }


### PR DESCRIPTION
While preparing the installers in:
* #104 

… I have noticed that finding the `testgen-hs` helper relied on the _current directory_. It shouldn’t, because the user can run our main executable from any directory, and it should behave in the same way.

Instead, I have added `current_exe_dir`, which points to the parent directory of our executable (`/proc/self/exe` on Linux etc.).

All search paths are also absolute now.

Previously, the Nix build didn’t work – unless the current directory was correct.

I removed directory recursion, as it's not necessary, and not what the kernel usually does when looking at `PATH` – IMO, let's keep it consistent with what the users are used to.

And the same logic is used to check for the file in each directory.

I'm not checking for the version yet, this will be done in:
* #115 