### PR TITLE
fix: unify json responses

### DIFF
--- a/src/api/root.rs
+++ b/src/api/root.rs
@@ -7,7 +7,6 @@ pub struct RootResponse {
     pub name: String,
     pub version: String,
     pub healthy: bool,
-    #[serde(rename = "nodeInfo")]
     pub node_info: NodeInfo,
     pub errors: Vec<String>,
 }
@@ -20,7 +19,7 @@ pub async fn route(
     let node_info = node.sync_progress().await?;
 
     let response = RootResponse {
-        name: "blockfrost-platform".to_string(),
+        name: env!("CARGO_PKG_NAME").to_string(),
         version: env!("CARGO_PKG_VERSION").to_string(),
         node_info,
         healthy: errors.is_empty(),

--- a/src/node/sync_progress.rs
+++ b/src/node/sync_progress.rs
@@ -12,7 +12,6 @@ pub struct NodeInfo {
     pub epoch: u32,
     pub era: String,
     pub slot: u64,
-    #[serde(rename = "syncProgress")]
     pub sync_progress: f64,
 }
 


### PR DESCRIPTION
As we already use https://docs.blockfrost.io/#description/errors

```json
{
  "status_code": 403,
  "error": "Forbidden",
  "message": "Invalid project token."
}
```

It would be a good idea to unify JSON responses and consistently use snake_case.

