### PR TITLE
One step closer to same response as blockfrost

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -124,8 +124,6 @@ impl BlockfrostError {
         }
     }
 
-    /// Our custom 400 error
-
     /// This error is converted in middleware to internal_server_error_user
     pub fn internal_server_error(error: String) -> Self {
         Self {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -29,10 +29,9 @@ pub enum AppError {
 /// - message: a longer description of the error
 #[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BlockfrostError {
-    pub status_code: u16,
     pub error: String,
     pub message: String,
-    pub details: Option<serde_json::Value>,
+    pub status_code: u16,
 }
 
 impl From<std::num::TryFromIntError> for BlockfrostError {
@@ -113,7 +112,6 @@ impl BlockfrostError {
             error: "Not Found".to_string(),
             message: "The requested component has not been found.".to_string(),
             status_code: 404,
-            details: None,
         }
     }
 
@@ -123,19 +121,10 @@ impl BlockfrostError {
             error: "Bad Request".to_string(),
             message,
             status_code: 400,
-            details: None,
         }
     }
 
     /// Our custom 400 error
-    pub fn custom_400_details(message: String, details: serde_json::Value) -> Self {
-        Self {
-            error: "Bad Request".to_string(),
-            message,
-            status_code: 400,
-            details: Some(details),
-        }
-    }
 
     /// This error is converted in middleware to internal_server_error_user
     pub fn internal_server_error(error: String) -> Self {
@@ -143,7 +132,6 @@ impl BlockfrostError {
             error: "Internal Server Error".to_string(),
             message: error,
             status_code: 500,
-            details: None,
         }
     }
 
@@ -153,7 +141,6 @@ impl BlockfrostError {
             error: "Internal Server Error".to_string(),
             message: "An unexpected response was received from the backend.".to_string(),
             status_code: 500,
-            details: None,
         }
     }
 

--- a/src/node/transactions.rs
+++ b/src/node/transactions.rs
@@ -54,10 +54,7 @@ impl NodeClient {
                             submit_api_json
                         );
 
-                        Err(BlockfrostError::custom_400_details(
-                            error_message,
-                            submit_api_json,
-                        ))
+                        Err(BlockfrostError::custom_400(submit_api_json.to_string()))
                     }
 
                     Err(e) => {

--- a/tests/endpoints_test.rs
+++ b/tests/endpoints_test.rs
@@ -86,6 +86,8 @@ mod tests {
 
         let local_body_str = String::from_utf8_lossy(&local_body_bytes);
 
+        // assert_eq!(bf_body_bytes, local_body_bytes,);
+
         assert!(
             local_body_str.contains("BadInputsUTxO"),
             "Expected 'BadInputsUTxO' in the local response, but it was not found."

--- a/tests/endpoints_test.rs
+++ b/tests/endpoints_test.rs
@@ -86,6 +86,7 @@ mod tests {
 
         let local_body_str = String::from_utf8_lossy(&local_body_bytes);
 
+        // Uncomment this to see the difference between the blockfrost response and platform response
         // assert_eq!(bf_body_bytes, local_body_bytes,);
 
         assert!(


### PR DESCRIPTION
In this format, only the `message` field is different.

https://app.warp.dev/block/ljaRyZihLHdISXLxpU5WdD