### PR TITLE
chore: update `testgen-hs` to 10.1.4.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     ls -l ; cargo chef prepare --recipe-path recipe.json
 
 FROM base AS downloader
-ADD https://github.com/input-output-hk/testgen-hs/releases/download/10.1.4.0/testgen-hs-10.1.4.0-x86_64-linux.tar.bz2 /app/
+ADD https://github.com/input-output-hk/testgen-hs/releases/download/10.1.4.1/testgen-hs-10.1.4.1-x86_64-linux.tar.bz2 /app/
 RUN tar -xjf testgen-hs-*.tar.* && /app/testgen-hs/testgen-hs --version
 
 FROM base AS builder

--- a/build.rs
+++ b/build.rs
@@ -22,7 +22,7 @@ fn main() {
     // Tell Cargo to rerun the build script if the build script itself changes.
     println!("cargo:rerun-if-changed=build.rs");
 
-    let testgen_lib_version = "10.1.4.0";
+    let testgen_lib_version = "10.1.4.1";
 
     let target_os = if cfg!(target_os = "macos") {
         "darwin"

--- a/flake.lock
+++ b/flake.lock
@@ -238,16 +238,16 @@
     "testgen-hs": {
       "flake": false,
       "locked": {
-        "lastModified": 1736946079,
-        "narHash": "sha256-nmi9i05h8AnhlqcHLhshx9Um94rzc2sbanb1laNBTI4=",
+        "lastModified": 1738671367,
+        "narHash": "sha256-9htTIILDoHsK+olKfED+3jo8dy5w2lmMT4OWLO0ZAD4=",
         "owner": "input-output-hk",
         "repo": "testgen-hs",
-        "rev": "a6193b7bd64eab1f1633331e1f55891321caee67",
+        "rev": "d8b08921cdcf47ea834acbc64b538fb7ff8d8cec",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "10.1.4.0",
+        "ref": "10.1.4.1",
         "repo": "testgen-hs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
     flake-compat.flake = false;
     cardano-node.url = "github:IntersectMBO/cardano-node/10.1.4";
     cardano-node.flake = false; # otherwise, +2k dependencies we don’t really use
-    testgen-hs.url = "github:input-output-hk/testgen-hs/10.1.4.0"; # make sure it follows cardano-node
+    testgen-hs.url = "github:input-output-hk/testgen-hs/10.1.4.1"; # make sure it follows cardano-node
     testgen-hs.flake = false; # otherwise, +2k dependencies we don’t really use
     devshell.url = "github:numtide/devshell";
     devshell.inputs.nixpkgs.follows = "nixpkgs";

--- a/nix/internal/windows.nix
+++ b/nix/internal/windows.nix
@@ -58,7 +58,7 @@ in rec {
     pkgs.fetchzip {
       name = "testgen-hs-${version}";
       url = "https://github.com/input-output-hk/testgen-hs/releases/download/${version}/testgen-hs-${version}-${targetSystem}.zip";
-      hash = "sha256-vRUtYueSDu+wSL8iQhlzqtBJBu8vIfBm2c7ynj/bqfU=";
+      hash = "sha256-a5/S7hQw5tIupJFbPG/5Pgb6l9Bw5nJX+jvt2WOqML0=";
     };
 
   nsis = import ./windows-nsis.nix {nsisNixpkgs = inputs.nixpkgs-nsis;};


### PR DESCRIPTION
The need to do so discovered by @ginnun in:
* #90

Via commit 7e13006519bb1792de103e548e69e89f4b35062c:

> fix: patch `Arbitrary PoolMetadata` to always have 32 bytes for `pmHash`

See also the fix in the upstream:
* https://github.com/IntersectMBO/cardano-ledger/pull/4870