### PR TITLE
chore: notarize the DMG artifacts

### DIFF
--- a/nix/internal/darwin-entitlements.xml
+++ b/nix/internal/darwin-entitlements.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+  </dict>
+</plist>


### PR DESCRIPTION
Resolves #152

## How to test

The pre-pre-release at [michalrus/bfp-release-testing/releases/tag/0.0.1](https://github.com/michalrus/bfp-release-testing/releases/tag/0.0.1) has been updated with properly signed, and notarized DMG images.

## Result

After mounting it:

```
❯ codesign -dv --verbose=2 "$(which blockfrost-platform)"
                         
Executable=/Volumes/Blockfrost Platform/Blockfrost Platform.app/Contents/MacOS/bundle/libexec/blockfrost-platform
Identifier=blockfrost-platform
Format=Mach-O thin (x86_64)
CodeDirectory v=20500 size=64991 flags=0x10000(runtime) hashes=2020+7 location=embedded
Signature size=8996
Authority=Developer ID Application: Input Output HK Limited (89TW38X994)
Authority=Developer ID Certification Authority
Authority=Apple Root CA
Timestamp=7 Feb 2025 at 17:00:23
Info.plist=not bound
TeamIdentifier=89TW38X994
Runtime Version=10.12.0
Sealed Resources=none
Internal requirements count=1 size=180
```

<img width="908" alt="image" src="https://github.com/user-attachments/assets/f8e3124b-bb4d-42d4-8628-81400de04e6d" />