### PR TITLE
chore: update `testgen-hs` to 10.1.4.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     ls -l ; cargo chef prepare --recipe-path recipe.json
 
 FROM base AS downloader
-ADD https://github.com/input-output-hk/testgen-hs/releases/download/10.1.4.1/testgen-hs-10.1.4.1-x86_64-linux.tar.bz2 /app/
+ADD https://github.com/input-output-hk/testgen-hs/releases/download/10.1.4.2/testgen-hs-10.1.4.2-x86_64-linux.tar.bz2 /app/
 RUN tar -xjf testgen-hs-*.tar.* && /app/testgen-hs/testgen-hs --version
 
 FROM base AS builder

--- a/build.rs
+++ b/build.rs
@@ -22,7 +22,7 @@ fn main() {
     // Tell Cargo to rerun the build script if the build script itself changes.
     println!("cargo:rerun-if-changed=build.rs");
 
-    let testgen_lib_version = "10.1.4.1";
+    let testgen_lib_version = "10.1.4.2";
 
     let target_os = if cfg!(target_os = "macos") {
         "darwin"

--- a/flake.lock
+++ b/flake.lock
@@ -238,16 +238,16 @@
     "testgen-hs": {
       "flake": false,
       "locked": {
-        "lastModified": 1738671367,
-        "narHash": "sha256-9htTIILDoHsK+olKfED+3jo8dy5w2lmMT4OWLO0ZAD4=",
+        "lastModified": 1739209084,
+        "narHash": "sha256-E50j7ZXQN0f1mmSqQW0hry45YfM0MTqLzDMZv56qA7U=",
         "owner": "input-output-hk",
         "repo": "testgen-hs",
-        "rev": "d8b08921cdcf47ea834acbc64b538fb7ff8d8cec",
+        "rev": "982ba180b8a5ac0f00437d2b38b94bd8b9a6612e",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "10.1.4.1",
+        "ref": "10.1.4.2",
         "repo": "testgen-hs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
     flake-compat.flake = false;
     cardano-node.url = "github:IntersectMBO/cardano-node/10.1.4";
     cardano-node.flake = false; # otherwise, +2k dependencies we don’t really use
-    testgen-hs.url = "github:input-output-hk/testgen-hs/10.1.4.1"; # make sure it follows cardano-node
+    testgen-hs.url = "github:input-output-hk/testgen-hs/10.1.4.2"; # make sure it follows cardano-node
     testgen-hs.flake = false; # otherwise, +2k dependencies we don’t really use
     devshell.url = "github:numtide/devshell";
     devshell.inputs.nixpkgs.follows = "nixpkgs";

--- a/nix/internal/windows.nix
+++ b/nix/internal/windows.nix
@@ -58,7 +58,7 @@ in rec {
     pkgs.fetchzip {
       name = "testgen-hs-${version}";
       url = "https://github.com/input-output-hk/testgen-hs/releases/download/${version}/testgen-hs-${version}-${targetSystem}.zip";
-      hash = "sha256-a5/S7hQw5tIupJFbPG/5Pgb6l9Bw5nJX+jvt2WOqML0=";
+      hash = "sha256-LXE1RBKgal1Twh7j2hpCfNLsBMEcqSwGHb4bj/Imd9Q=";
     };
 
   nsis = import ./windows-nsis.nix {nsisNixpkgs = inputs.nixpkgs-nsis;};


### PR DESCRIPTION
## Context

* Backported from @ginnun's:
  * #90
  * #157

* Let's make sure it still works on `main`.

* Related Haskell side changes (only in test case generator): [input-output-hk/testgen-hs/compare/10.1.4.1..10.1.4.2](https://github.com/input-output-hk/testgen-hs/compare/10.1.4.1..10.1.4.2).