### PR TITLE
chore: simplify `nix build` in the docs

### DIFF
--- a/docs/src/content/installation/nix.md
+++ b/docs/src/content/installation/nix.md
@@ -3,21 +3,20 @@
 If you are using Nix, building `blockfrost-platform` is straightforward.
 
 ```bash
-# Clone the repository
-git clone https://github.com/blockfrost/blockfrost-platform
-
-# Navigate to the project directory
-cd blockfrost-platform
-
 # To build the latest main version (experimental)
-git checkout main
+nix build github:blockfrost/blockfrost-platform
 
 # To build a release version (recommended)
 # NOTE: this option will be available after the first release
-# git checkout v0.1
+nix build github:blockfrost/blockfrost-platform/v0.1
+```
 
-# Build the project using nix
-nix build
+To make the builds much faster, it’s worth adding the IOG binary cache to your Nix configuration (`/etc/nix/nix.conf`):
+
+```
+substituters = https://cache.nixos.org https://cache.iog.io
+
+trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
 ```
 
 After the build is complete, you should see the binary file and can move on to the

--- a/docs/src/content/usage/configuration.mdx
+++ b/docs/src/content/usage/configuration.mdx
@@ -20,4 +20,4 @@ Config has been written to "/Users/blockfrost/Library/Application Support/blockf
 
 Unless you know what you are doing, we recommend you to keep the default settings, except for the Cardano node socket, the reward address and the secret which are specific to your own setup.
 
-As you can see, the example above is from macOS. On Linux, you will find it at `~/.config/blockfrost/config.toml`
+As you can see, the example above is from macOS. On Linux, you will find it at `~/.config/blockfrost-platform/config.toml`


### PR DESCRIPTION
## Context

* I noticed in the [Using Nix](https://platform.blockfrost.io/installation/nix) section, that it could be simplified by avoiding cloning of the repo.

* More controversial: I also suggested adding IOG substituters as an option to make the build (download) really fast.

* I also found that the Linux config path was the old one (`~/.config/blockfrost` instead of `~/.config/blockfrost-platform`).