### PR TITLE
feat: accept both binary and hex-encoded transactions (heuristically)

### DIFF
--- a/src/api/tx_submit.rs
+++ b/src/api/tx_submit.rs
@@ -4,14 +4,14 @@ use axum::{http::HeaderMap, response::IntoResponse, Extension, Json};
 pub async fn route(
     Extension(node): Extension<NodePool>,
     headers: HeaderMap,
-    body: String,
+    body: axum::body::Bytes,
 ) -> Result<impl IntoResponse, BlockfrostError> {
     // Allow only application/cbor content type
     validate_content_type(&headers, &["application/cbor"])?;
 
     // Submit transaction
     let mut node = node.get().await?;
-    let response = node.submit_transaction(body).await?;
+    let response = node.submit_transaction(body.as_ref()).await?;
 
     Ok(Json(response))
 }


### PR DESCRIPTION
Relates to #19

## Context

* We want to be able to accept both binary and hex-encoded CBOR transactions (see [this Slack thread](https://input-output-rnd.slack.com/archives/C07FD0DNEMQ/p1739450796177289?thread_ts=1739378737.982579&cid=C07FD0DNEMQ)).

* See the comment near the new function for an explanation how it works.

## Result

Now, `blockfrost-platform` accepts both binary and hex-encoded CBOR transactions:

![image](https://github.com/user-attachments/assets/7e98b4b0-0ccd-4df5-bf15-65632c86b594)
