### PR TITLE
chore: check for `bzip2` in `curl-bash-install.sh`

### DIFF
--- a/nix/internal/curl-bash-install.sh
+++ b/nix/internal/curl-bash-install.sh
@@ -48,6 +48,11 @@ install_dir_expr="${opt_dir_expr}/${project_name}"
 bin_dir="${install_dir}/bin"
 bin_dir_expr="${install_dir_expr}/bin"
 
+if ! command -v bzip2 >/dev/null 2>&1; then
+  echo >&2 "fatal: bzip2 not found, please install it, and try again"
+  exit 1
+fi
+
 echo >&2 "info: downloading ${color_bold}${archive_url}${color_reset}"
 echo >&2 "info: saving to ${color_bold}${download_path}${color_reset}"
 


### PR DESCRIPTION
## Context

@mmahut found out that `bzip2` is not installed by default on the latest Fedora right after installation.

Let’s have a better error message than:

```
tar (child): bzip2: Cannot exec: No such file or directory
```