### PR TITLE
breaking: Fix metrics endpoint and enable by default

### DIFF
--- a/src/api/metrics.rs
+++ b/src/api/metrics.rs
@@ -6,15 +6,11 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 pub async fn route(
-    Extension(prometheus_handle): Extension<Option<Arc<RwLock<PrometheusHandle>>>>,
+    Extension(prometheus_handle): Extension<Arc<RwLock<PrometheusHandle>>>,
 ) -> Result<impl IntoResponse, BlockfrostError> {
-    match prometheus_handle {
-        None => Err(BlockfrostError::not_found()),
-        Some(handle) => {
-            let handle = handle.write().await;
-            Ok(handle.render().into_response())
-        }
-    }
+    let handle = prometheus_handle.write().await;
+
+    Ok(handle.render().into_response())
 }
 
 pub fn setup_metrics_recorder() -> Arc<RwLock<PrometheusHandle>> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -62,8 +62,8 @@ pub struct Args {
     #[arg(long)]
     reward_address: Option<String>,
 
-    #[arg(long, default_value = "true", required = false)]
-    metrics: bool,
+    #[arg(long)]
+    no_metrics: bool,
 }
 
 fn get_config_path() -> PathBuf {
@@ -206,7 +206,7 @@ impl Args {
             config: None,
             solitary: is_solitary,
             network: Some(network),
-            metrics,
+            no_metrics: !metrics,
             mode,
             log_level,
             server_address,
@@ -293,7 +293,7 @@ pub struct Config {
     pub icebreakers_config: Option<IcebreakersConfig>,
     pub max_pool_connections: usize,
     pub network: Network,
-    pub metrics: bool,
+    pub no_metrics: bool,
 }
 
 #[derive(Clone)]
@@ -337,7 +337,7 @@ impl Config {
             mode: args.mode,
             icebreakers_config,
             max_pool_connections: 10,
-            metrics: args.metrics,
+            no_metrics: args.no_metrics,
             network,
         })
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -146,7 +146,7 @@ impl Args {
             .prompt()?;
 
         let metrics = Confirm::new("Enable metrics?")
-            .with_default(false)
+            .with_default(true)
             .with_help_message("Should metrics be enabled?")
             .prompt()?;
 

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -36,7 +36,7 @@ pub fn test_config() -> Arc<Config> {
         icebreakers_config: None,
         max_pool_connections: 10,
         network: Network::Preview,
-        metrics: false,
+        no_metrics: false,
     };
 
     Arc::new(config)
@@ -55,19 +55,3 @@ pub async fn build_app() -> Result<
 
     build(config).await
 }
-
-// TODO: https://github.com/blockfrost/blockfrost-platform/issues/19
-// fn prettify_json(s: &[u8]) -> String {
-//     let json_value: Value = from_slice(s).expect("Invalid JSON data");
-
-//     serde_json::to_string_pretty(&json_value).expect("Failed to serialize JSON")
-// }
-
-// TODO: https://github.com/blockfrost/blockfrost-platform/issues/19
-// pub fn _compare_pretty_jsons(s1: Bytes, s2: Bytes) {
-//     assert_eq!(
-//         prettify_json(&s1),
-//         prettify_json(&s2),
-//         "JSON strings are not equal"
-//     );
-// }

--- a/tests/endpoints_test.rs
+++ b/tests/endpoints_test.rs
@@ -41,6 +41,34 @@ mod tests {
         assert_eq!(root_response.node_info.sync_progress, 100.0);
     }
 
+    // Test: `/metrics` route sanity check
+    #[tokio::test]
+    async fn test_metrics_route() {
+        initialize_logging();
+
+        let (app, _, _, _) = build_app().await.expect("Failed to build the application");
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/metrics")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("Request to /metrics route failed");
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body_bytes = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("Failed to read response body");
+
+        let body_str = String::from_utf8(body_bytes.to_vec()).unwrap();
+
+        assert!(body_str.contains("cardano_node_connections"));
+    }
+
     // Test: `/tx/submit` error has same response as blockfrost API
     #[tokio::test]
     async fn test_submit_route_error() {

--- a/tests/endpoints_test.rs
+++ b/tests/endpoints_test.rs
@@ -17,7 +17,7 @@ mod tests {
 
     // Test: `/` route correct response
     #[tokio::test]
-    async fn test_root_route() {
+    async fn test_route_root() {
         initialize_logging();
 
         let (app, _, _, _) = build_app().await.expect("Failed to build the application");
@@ -43,7 +43,7 @@ mod tests {
 
     // Test: `/metrics` route sanity check
     #[tokio::test]
-    async fn test_metrics_route() {
+    async fn test_route_metrics() {
         initialize_logging();
 
         let (app, _, _, _) = build_app().await.expect("Failed to build the application");
@@ -71,7 +71,7 @@ mod tests {
 
     // Test: `/tx/submit` error has same response as blockfrost API
     #[tokio::test]
-    async fn test_submit_route_error() {
+    async fn test_route_submit() {
         initialize_logging();
         let (app, _, _, _) = build_app().await.expect("Failed to build the application");
 


### PR DESCRIPTION
Fixes https://github.com/blockfrost/blockfrost-platform/issues/179

**Breaking Changes**
- Replaced `--metrics` with `--no-metrics` 
- Metrics are enabled by default when running via CLI without  `--no-metrics` 

**Changes**
- `/metrics`  url is no longer handled if metrics are disabled
- HTTP calls are no longer gauged  if metrics are disabled