### PR TITLE
fix: never let Axum abort Ouroboros miniprotocols on HTTP client disconnect

### DIFF
--- a/src/api/metrics.rs
+++ b/src/api/metrics.rs
@@ -1,4 +1,4 @@
-use crate::{cli::Config, BlockfrostError};
+use crate::BlockfrostError;
 use axum::response::{Extension, IntoResponse};
 use metrics::{describe_counter, describe_gauge, gauge};
 use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
@@ -6,22 +6,24 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 pub async fn route(
-    Extension(prometheus_handle): Extension<Arc<RwLock<PrometheusHandle>>>,
-    Extension(config): Extension<Arc<Config>>,
+    Extension(prometheus_handle): Extension<Option<Arc<RwLock<PrometheusHandle>>>>,
 ) -> Result<impl IntoResponse, BlockfrostError> {
-    if !config.metrics {
-        return Err(BlockfrostError::not_found());
+    match prometheus_handle {
+        None => Err(BlockfrostError::not_found()),
+        Some(handle) => {
+            let handle = handle.write().await;
+            Ok(handle.render().into_response())
+        }
     }
-
-    let handle = prometheus_handle.write().await;
-
-    Ok(handle.render().into_response())
 }
 
 pub fn setup_metrics_recorder() -> Arc<RwLock<PrometheusHandle>> {
     let builder = PrometheusBuilder::new()
         .install_recorder()
         .expect("failed to install Prometheus recorder");
+
+    // Note: we’re initializing the gauges with 0, otherwise they’re not present
+    // under `GET /metrics` right after startup, before anything happens.
 
     describe_counter!(
         "http_requests_total",
@@ -32,9 +34,31 @@ pub fn setup_metrics_recorder() -> Arc<RwLock<PrometheusHandle>> {
         "cardano_node_connections",
         "Number of currently open Cardano node N2C connections"
     );
-
-    // Otherwise it’s not present under `GET /metrics` if we start with a failing cardano-node:
     gauge!("cardano_node_connections").set(0);
+
+    describe_gauge!(
+        "cardano_node_connections_initiated",
+        "Number of Cardano node N2C connections that have ever been initiated"
+    );
+    gauge!("cardano_node_connections_initiated").set(0);
+
+    describe_gauge!(
+        "cardano_node_connections_failed",
+        "Number of Cardano node N2C connections that failed and had to be restarted"
+    );
+    gauge!("cardano_node_connections_failed").set(0);
+
+    describe_gauge!(
+        "tx_submit_success",
+        "Number of transactions that were successfully submitted"
+    );
+    gauge!("tx_submit_success").set(0);
+
+    describe_gauge!(
+        "tx_submit_failure",
+        "Number of transactions that were submitted with an error"
+    );
+    gauge!("tx_submit_failure").set(0);
 
     Arc::new(RwLock::new(builder))
 }

--- a/src/api/tx_submit.rs
+++ b/src/api/tx_submit.rs
@@ -1,5 +1,6 @@
 use crate::{common::validate_content_type, BlockfrostError, NodePool};
 use axum::{http::HeaderMap, response::IntoResponse, Extension, Json};
+use metrics::gauge;
 
 pub async fn route(
     Extension(node): Extension<NodePool>,
@@ -9,9 +10,22 @@ pub async fn route(
     // Allow only application/cbor content type
     validate_content_type(&headers, &["application/cbor"])?;
 
-    // Submit transaction
-    let mut node = node.get().await?;
-    let response = node.submit_transaction(body.as_ref()).await?;
+    // XXX: Axum must not abort Ouroboros protocols in the middle, hence a separate Tokio task:
+    let response = tokio::spawn(async move {
+        // Submit transaction
+        let mut node = node.get().await?;
+        let response = node.submit_transaction(body.as_ref()).await;
+
+        if response.is_ok() {
+            gauge!("tx_submit_success").increment(1)
+        } else {
+            gauge!("tx_submit_failure").increment(1)
+        }
+
+        response
+    })
+    .await
+    .expect("submit_transaction panic!")?;
 
     Ok(Json(response))
 }


### PR DESCRIPTION
Resolves #173

Resolves #175

## Context

Originally reported as:
* #173 

This is a good explanation – https://github.com/blockfrost/blockfrost-platform/issues/173#issuecomment-2666748539:
> * This happens on machines with high load average.
> * Then `GET /` takes a significant while.
> * But the requester doesn’t wait that long, and disconnects.
> * This results in **Axum cancelling the handling future**.
> * And that’s why our code never calls `client.send_release().await` from Pallas.
> * But the connection is returned to the pool in its `impl Drop`.
> * So the next time we try to use it, it’s in incorrect state (not released), and we try to acquire, and that’s an error, which eventually results in `N2C connection no longer viable`.

## Additional work included

I also added a few more gauges to better instrument the code, and understand what’s happening, and I think they will be useful in general, so I left them in.