### PR TITLE
chore: embed Git revision in the final binary (and other minor changes)

### DIFF
--- a/.github/workflows/oci-image.yaml
+++ b/.github/workflows/oci-image.yaml
@@ -15,7 +15,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: 🚀 Build the image
         run: |
-          docker compose build
+          docker compose build --build-arg GIT_REVISION=$(git rev-parse @)
       - name: 📤 Push the image
         if: github.ref == 'refs/heads/main'
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cargo chef cook --release --workspace --recipe-path recipe.json
 COPY ./src	./src
 COPY Cargo.toml	Cargo.lock	./
+ARG GIT_REVISION
+ENV GIT_REVISION=$GIT_REVISION
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
     cargo build --release

--- a/build.rs
+++ b/build.rs
@@ -1,191 +1,229 @@
-use bzip2::read::BzDecoder;
-use std::{
-    env,
-    fs::{create_dir_all, write as fs_write, File},
-    path::{Path, PathBuf},
-    process::Command,
-};
-use tar::Archive;
-use zip::ZipArchive;
-
-const TESTGEN_HS_PATH: &str = "TESTGEN_HS_PATH";
-
 fn main() {
-    if env::var(TESTGEN_HS_PATH).is_ok() {
-        println!(
-            "Environment variable {} is set. Exiting the build script.",
-            TESTGEN_HS_PATH
-        );
-        return;
-    }
+    git_revision::set();
+    testgen_hs::ensure();
+}
 
-    // Tell Cargo to rerun the build script if the build script itself changes.
-    println!("cargo:rerun-if-changed=build.rs");
+mod git_revision {
+    use std::env;
 
-    let testgen_lib_version = "10.1.4.2";
+    const GIT_REVISION: &str = "GIT_REVISION";
 
-    let target_os = if cfg!(target_os = "macos") {
-        "darwin"
-    } else if cfg!(target_os = "linux") {
-        "linux"
-    } else if cfg!(target_os = "windows") {
-        "windows"
-    } else {
-        panic!("Unsupported OS");
-    };
+    pub fn set() {
+        use std::process::Command;
 
-    let arch = if cfg!(target_arch = "x86_64") {
-        "x86_64"
-    } else if cfg!(target_arch = "aarch64") {
-        "aarch64"
-    } else {
-        panic!("Unsupported architecture");
-    };
-
-    let suffix = if target_os == "windows" {
-        ".zip"
-    } else {
-        ".tar.bz2"
-    };
-
-    let file_name = format!("testgen-hs-{}-{}-{}", testgen_lib_version, arch, target_os);
-    let download_url = format!(
-        "https://github.com/input-output-hk/testgen-hs/releases/download/{}/{}{}",
-        testgen_lib_version, file_name, suffix
-    );
-
-    println!("Fetching {}", file_name);
-
-    // Use the project’s target directory instead of a system cache location.
-    let cargo_manifest_dir =
-        env::var("CARGO_MANIFEST_DIR").expect("Unable to find CARGO_MANIFEST_DIR");
-
-    let cargo_target_dir = PathBuf::from(&cargo_manifest_dir)
-        .join(env::var("CARGO_TARGET_DIR").unwrap_or_else(|_| "target".into()));
-
-    let download_dir = cargo_target_dir.join("testgen-hs");
-
-    create_dir_all(&download_dir).expect("Unable to create testgen directory");
-
-    let archive_name = if target_os == "windows" {
-        format!("{}.zip", file_name)
-    } else {
-        format!("{}.tar.bz2", file_name)
-    };
-
-    let archive_path = download_dir.join(&archive_name);
-
-    // Download the artifact if not already in the target directory.
-    if !archive_path.exists() {
-        println!("Downloading from: {}", download_url);
-
-        let response = reqwest::blocking::get(&download_url)
-            .expect("Failed to download archive")
-            .bytes()
-            .expect("Failed to read archive");
-
-        fs_write(&archive_path, &response).expect("Failed to write archive to disk");
-
-        println!("Downloaded to: {}", archive_path.display());
-    } else {
-        println!("Using existing archive at: {}", archive_path.display());
-    }
-
-    // Either `debug` or `release`:
-    let cargo_profile = env::var("PROFILE").expect("Could not read PROFILE");
-
-    // Extraction path inside the target directory.
-    let extract_dir = cargo_target_dir.join(cargo_profile);
-    create_dir_all(&extract_dir).expect("Unable to create extraction directory");
-
-    let testgen_hs_dir = extract_dir.join("testgen-hs");
-
-    // Extract the artifact if not already extracted.
-    if !testgen_hs_dir.exists() {
-        println!("Extracting archive...");
-        if target_os == "windows" {
-            extract_zip(&archive_path, &extract_dir);
-        } else {
-            extract_tar_bz2(&archive_path, &extract_dir);
+        if env::var(GIT_REVISION).is_ok() {
+            println!("Environment variable {} is set. Not setting.", GIT_REVISION);
+            return;
         }
-    } else {
-        println!("Already extracted at: {}", extract_dir.display());
-    }
 
-    // Path to the testgen-hs executable.
-    let executable = if target_os == "windows" {
-        testgen_hs_dir.join("testgen-hs.exe")
-    } else {
-        testgen_hs_dir.join("testgen-hs")
-    };
+        let git_status = Command::new("git")
+            .args(["status", "--porcelain"])
+            .output()
+            .expect("git-status");
 
-    // Verify version by running --version.
-    println!("Verifying testgen-hs version...");
-    println!("Executing: {:?}", executable);
-
-    let output = Command::new(&executable)
-        .arg("--version")
-        .output()
-        .expect("Failed to execute testgen-hs");
-
-    if !output.status.success() {
-        panic!(
-            "testgen-hs exited with status {}",
-            output.status.code().unwrap_or(-1)
-        );
-    }
-
-    let version_output = String::from_utf8_lossy(&output.stdout);
-    println!("testgen-hs version: {}", version_output.trim());
-
-    let testgen_lib_version = format!("testgen-hs {}", testgen_lib_version);
-
-    if version_output.trim() != testgen_lib_version {
-        panic!(
-            "Expected testgen-hs version {} but got {}",
-            version_output.trim(),
-            testgen_lib_version
-        );
-    }
-
-    // Set environment variable for downstream build steps.
-    println!(
-        "cargo:rustc-env={}={}",
-        TESTGEN_HS_PATH,
-        executable.to_string_lossy()
-    );
-}
-
-fn extract_tar_bz2(archive_path: &PathBuf, extract_dir: &PathBuf) {
-    let tar_bz2 = File::open(archive_path).expect("Failed to open .tar.bz2 archive");
-    let tar = BzDecoder::new(tar_bz2);
-    let mut archive = Archive::new(tar);
-
-    archive
-        .unpack(extract_dir)
-        .expect("Failed to extract .tar.bz2 archive");
-}
-
-fn extract_zip(archive_path: &PathBuf, extract_dir: &Path) {
-    let file = File::open(archive_path).expect("Failed to open .zip archive");
-    let mut archive = ZipArchive::new(file).expect("Failed to read .zip archive");
-
-    for i in 0..archive.len() {
-        let mut entry = archive.by_index(i).expect("Invalid entry in .zip archive");
-        let outpath = match entry.enclosed_name() {
-            Some(path) => extract_dir.join(path),
-            None => continue,
+        let revision = if !git_status.stdout.is_empty() {
+            "dirty".to_string()
+        } else {
+            let git_rev_parse = Command::new("git")
+                .args(["rev-parse", "HEAD"])
+                .output()
+                .expect("git-rev-parse");
+            String::from_utf8_lossy(&git_rev_parse.stdout)
+                .trim()
+                .to_string()
         };
 
-        if entry.is_dir() {
-            create_dir_all(&outpath).expect("Unable to create directory");
-        } else {
-            if let Some(parent) = outpath.parent() {
-                create_dir_all(parent).expect("Unable to create parent directory");
-            }
+        println!("cargo:rustc-env={}={}", GIT_REVISION, revision);
+    }
+}
 
-            let mut outfile = File::create(&outpath).expect("Unable to create file");
-            std::io::copy(&mut entry, &mut outfile).expect("Unable to write file");
+mod testgen_hs {
+    use bzip2::read::BzDecoder;
+    use std::{
+        env,
+        fs::{create_dir_all, write as fs_write, File},
+        path::{Path, PathBuf},
+        process::Command,
+    };
+    use tar::Archive;
+    use zip::ZipArchive;
+
+    const TESTGEN_HS_PATH: &str = "TESTGEN_HS_PATH";
+
+    pub fn ensure() {
+        if env::var(TESTGEN_HS_PATH).is_ok() {
+            println!(
+                "Environment variable {} is set. Skipping the download.",
+                TESTGEN_HS_PATH
+            );
+            return;
+        }
+
+        let testgen_lib_version = "10.1.4.2";
+
+        let target_os = if cfg!(target_os = "macos") {
+            "darwin"
+        } else if cfg!(target_os = "linux") {
+            "linux"
+        } else if cfg!(target_os = "windows") {
+            "windows"
+        } else {
+            panic!("Unsupported OS");
+        };
+
+        let arch = if cfg!(target_arch = "x86_64") {
+            "x86_64"
+        } else if cfg!(target_arch = "aarch64") {
+            "aarch64"
+        } else {
+            panic!("Unsupported architecture");
+        };
+
+        let suffix = if target_os == "windows" {
+            ".zip"
+        } else {
+            ".tar.bz2"
+        };
+
+        let file_name = format!("testgen-hs-{}-{}-{}", testgen_lib_version, arch, target_os);
+        let download_url = format!(
+            "https://github.com/input-output-hk/testgen-hs/releases/download/{}/{}{}",
+            testgen_lib_version, file_name, suffix
+        );
+
+        println!("Looking for {}", file_name);
+
+        // Use the project’s target directory instead of a system cache location.
+        let cargo_manifest_dir =
+            env::var("CARGO_MANIFEST_DIR").expect("Unable to find CARGO_MANIFEST_DIR");
+
+        let cargo_target_dir = PathBuf::from(&cargo_manifest_dir)
+            .join(env::var("CARGO_TARGET_DIR").unwrap_or_else(|_| "target".into()));
+
+        let download_dir = cargo_target_dir.join("testgen-hs");
+
+        create_dir_all(&download_dir).expect("Unable to create testgen directory");
+
+        let archive_name = if target_os == "windows" {
+            format!("{}.zip", file_name)
+        } else {
+            format!("{}.tar.bz2", file_name)
+        };
+
+        let archive_path = download_dir.join(&archive_name);
+
+        // Download the artifact if not already in the target directory.
+        if !archive_path.exists() {
+            println!("Downloading from: {}", download_url);
+
+            let response = reqwest::blocking::get(&download_url)
+                .expect("Failed to download archive")
+                .bytes()
+                .expect("Failed to read archive");
+
+            fs_write(&archive_path, &response).expect("Failed to write archive to disk");
+
+            println!("Downloaded to: {}", archive_path.display());
+        } else {
+            println!("Using existing archive at: {}", archive_path.display());
+        }
+
+        // Either `debug` or `release`:
+        let cargo_profile = env::var("PROFILE").expect("Could not read PROFILE");
+
+        // Extraction path inside the target directory.
+        let extract_dir = cargo_target_dir.join(cargo_profile);
+        create_dir_all(&extract_dir).expect("Unable to create extraction directory");
+
+        let testgen_hs_dir = extract_dir.join("testgen-hs");
+
+        // Extract the artifact if not already extracted.
+        if !testgen_hs_dir.exists() {
+            println!("Extracting archive...");
+            if target_os == "windows" {
+                extract_zip(&archive_path, &extract_dir);
+            } else {
+                extract_tar_bz2(&archive_path, &extract_dir);
+            }
+        } else {
+            println!("Already extracted at: {}", extract_dir.display());
+        }
+
+        // Path to the testgen-hs executable.
+        let executable = if target_os == "windows" {
+            testgen_hs_dir.join("testgen-hs.exe")
+        } else {
+            testgen_hs_dir.join("testgen-hs")
+        };
+
+        // Verify version by running --version.
+        println!("Verifying testgen-hs version...");
+        println!("Executing: {:?}", executable);
+
+        let output = Command::new(&executable)
+            .arg("--version")
+            .output()
+            .expect("Failed to execute testgen-hs");
+
+        if !output.status.success() {
+            panic!(
+                "testgen-hs exited with status {}",
+                output.status.code().unwrap_or(-1)
+            );
+        }
+
+        let version_output = String::from_utf8_lossy(&output.stdout);
+        println!("testgen-hs version: {}", version_output.trim());
+
+        let testgen_lib_version = format!("testgen-hs {}", testgen_lib_version);
+
+        if version_output.trim() != testgen_lib_version {
+            panic!(
+                "Expected testgen-hs version {} but got {}",
+                version_output.trim(),
+                testgen_lib_version
+            );
+        }
+
+        // Set environment variable for downstream build steps.
+        println!(
+            "cargo:rustc-env={}={}",
+            TESTGEN_HS_PATH,
+            executable.to_string_lossy()
+        );
+    }
+
+    fn extract_tar_bz2(archive_path: &PathBuf, extract_dir: &PathBuf) {
+        let tar_bz2 = File::open(archive_path).expect("Failed to open .tar.bz2 archive");
+        let tar = BzDecoder::new(tar_bz2);
+        let mut archive = Archive::new(tar);
+
+        archive
+            .unpack(extract_dir)
+            .expect("Failed to extract .tar.bz2 archive");
+    }
+
+    fn extract_zip(archive_path: &PathBuf, extract_dir: &Path) {
+        let file = File::open(archive_path).expect("Failed to open .zip archive");
+        let mut archive = ZipArchive::new(file).expect("Failed to read .zip archive");
+
+        for i in 0..archive.len() {
+            let mut entry = archive.by_index(i).expect("Invalid entry in .zip archive");
+            let outpath = match entry.enclosed_name() {
+                Some(path) => extract_dir.join(path),
+                None => continue,
+            };
+
+            if entry.is_dir() {
+                create_dir_all(&outpath).expect("Unable to create directory");
+            } else {
+                if let Some(parent) = outpath.parent() {
+                    create_dir_all(parent).expect("Unable to create parent directory");
+                }
+
+                let mut outfile = File::create(&outpath).expect("Unable to create file");
+                std::io::copy(&mut entry, &mut outfile).expect("Unable to write file");
+            }
         }
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,8 @@ services:
     build:
       context: ./
       target: runtime
+      args:
+        - GIT_REVISION
     develop:
       watch:
         - action: rebuild

--- a/nix/internal/darwin.nix
+++ b/nix/internal/darwin.nix
@@ -41,16 +41,16 @@ in
 
     # Portable directory that can be run on any modern Darwin:
     bundle =
-      (nix-bundle-exe-lib-subdir "${unix.package}/libexec/blockfrost-platform")
+      (nix-bundle-exe-lib-subdir "${unix.package}/libexec/${unix.packageName}")
       .overrideAttrs (drv: {
-        name = "blockfrost-platform";
+        name = unix.packageName;
         buildCommand =
           drv.buildCommand
           + ''
             mkdir -p $out/libexec
-            mv $out/{blockfrost-platform,lib} $out/libexec
+            mv $out/{${unix.packageName},lib} $out/libexec
             mkdir -p $out/bin
-            ( cd $out/bin ; ln -s ../libexec/blockfrost-platform ./ ; )
+            ( cd $out/bin ; ln -s ../libexec/${unix.packageName} ./ ; )
             cp -r ${bundle-testgen-hs} $out/libexec/testgen-hs
           '';
       });

--- a/nix/internal/linux.nix
+++ b/nix/internal/linux.nix
@@ -33,15 +33,15 @@ in
         bin_dir = "bin";
         exe_dir = "exe";
         lib_dir = "lib";
-      } "${unix.package}/libexec/blockfrost-platform")
+      } "${unix.package}/libexec/${unix.packageName}")
       .overrideAttrs (drv: {
-        name = "blockfrost-platform";
+        name = unix.packageName;
         buildCommand =
           drv.buildCommand
           + ''
             mkdir -p $out/lib/testgen-hs
             cp ${lib.getExe unix.testgen-hs} $out/lib/testgen-hs/
-            ( cd $out ; ln -s bin/blockfrost-platform . ; )
+            ( cd $out ; ln -s bin/${unix.packageName} . ; )
           '';
       });
   }

--- a/nix/internal/unix.nix
+++ b/nix/internal/unix.nix
@@ -57,6 +57,7 @@ in
           mkdir -p $out/bin
           ln -sf $out/libexec/${packageName} $out/bin/
         '';
+        meta.mainProgram = packageName;
       });
 
     cargoChecks = {

--- a/nix/internal/unix.nix
+++ b/nix/internal/unix.nix
@@ -46,9 +46,11 @@ in
 
     packageName = (craneLib.crateNameFromCargoToml {cargoToml = src + "/Cargo.toml";}).pname;
 
+    GIT_REVISION = inputs.self.rev or "dirty";
+
     package = craneLib.buildPackage (commonArgs
       // {
-        inherit cargoArtifacts;
+        inherit cargoArtifacts GIT_REVISION;
         doCheck = false; # we run tests with `cargo-nextest` below
         postInstall = ''
           chmod -R +w $out
@@ -63,15 +65,15 @@ in
     cargoChecks = {
       cargo-clippy = craneLib.cargoClippy (commonArgs
         // {
-          inherit cargoArtifacts;
+          inherit cargoArtifacts GIT_REVISION;
           # Maybe also add `--deny clippy::pedantic`?
           cargoClippyExtraArgs = "--all-targets --all-features -- --deny warnings";
         });
 
       cargo-doc = craneLib.cargoDoc (commonArgs
         // {
+          inherit cargoArtifacts GIT_REVISION;
           RUSTDOCFLAGS = "-D warnings";
-          inherit cargoArtifacts;
         });
 
       cargo-audit = craneLib.cargoAudit {
@@ -85,7 +87,7 @@ in
 
       cargo-test = craneLib.cargoNextest (commonArgs
         // {
-          inherit cargoArtifacts;
+          inherit cargoArtifacts GIT_REVISION;
           cargoNextestExtraArgs = "--lib";
         });
     };

--- a/nix/internal/unix.nix
+++ b/nix/internal/unix.nix
@@ -44,6 +44,8 @@ in
     # For better caching:
     cargoArtifacts = craneLib.buildDepsOnly commonArgs;
 
+    packageName = (craneLib.crateNameFromCargoToml {cargoToml = src + "/Cargo.toml";}).pname;
+
     package = craneLib.buildPackage (commonArgs
       // {
         inherit cargoArtifacts;
@@ -53,7 +55,7 @@ in
           mv $out/bin $out/libexec
           ln -sf ${testgen-hs}/bin $out/libexec/testgen-hs
           mkdir -p $out/bin
-          ln -sf $out/libexec/blockfrost-platform $out/bin/
+          ln -sf $out/libexec/${packageName} $out/bin/
         '';
       });
 
@@ -127,8 +129,8 @@ in
 
     stateDir =
       if pkgs.stdenv.isDarwin
-      then "Library/Application Support/blockfrost-platform"
-      else ".local/share/blockfrost-platform";
+      then "Library/Application Support/${packageName}"
+      else ".local/share/${packageName}";
 
     runNode = network:
       pkgs.writeShellScriptBin "run-node-${network}" ''
@@ -208,7 +210,7 @@ in
     curl-bash-install =
       pkgs.runCommandNoCC "curl-bash-install" {
         nativeBuildInputs = with pkgs; [shellcheck];
-        projectName = package.pname;
+        projectName = packageName;
         projectVersion = package.version;
         shortRev = inputs.self.shortRev or "dirty";
         baseUrl = releaseBaseUrl;

--- a/nix/internal/windows.nix
+++ b/nix/internal/windows.nix
@@ -42,6 +42,8 @@ in rec {
   # For better caching:
   cargoArtifacts = craneLib.buildDepsOnly commonArgs;
 
+  packageName = (craneLib.crateNameFromCargoToml {cargoToml = src + "/Cargo.toml";}).pname;
+
   package = craneLib.buildPackage (commonArgs
     // {
       inherit cargoArtifacts;
@@ -125,9 +127,9 @@ in rec {
       buildInputs = with pkgs; [zip];
       outFileName = "${package.pname}-${package.version}-${inputs.self.shortRev or "dirty"}-${targetSystem}.zip";
     } ''
-      cp -r ${bundle} blockfrost-platform
+      cp -r ${bundle} ${packageName}
       mkdir -p $out
-      zip -q -r $out/$outFileName blockfrost-platform/
+      zip -q -r $out/$outFileName ${packageName}/
 
       # Make it downloadable from Hydra:
       mkdir -p $out/nix-support
@@ -189,6 +191,6 @@ in rec {
         fi
       ''}
       mkdir -p $out
-      mv with-icon.exe $out/blockfrost-platform.exe
+      mv with-icon.exe $out/${packageName}.exe
     '';
 }

--- a/nix/internal/windows.nix
+++ b/nix/internal/windows.nix
@@ -44,9 +44,11 @@ in rec {
 
   packageName = (craneLib.crateNameFromCargoToml {cargoToml = src + "/Cargo.toml";}).pname;
 
+  GIT_REVISION = inputs.self.rev or "dirty";
+
   package = craneLib.buildPackage (commonArgs
     // {
-      inherit cargoArtifacts;
+      inherit cargoArtifacts GIT_REVISION;
       doCheck = false; # we run Windows tests on real Windows on GHA
       postPatch = ''
         sed -r '/^build = .*/d' -i Cargo.toml

--- a/src/api/root.rs
+++ b/src/api/root.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 pub struct RootResponse {
     pub name: String,
     pub version: String,
+    pub revision: String,
     pub healthy: bool,
     pub node_info: NodeInfo,
     pub errors: Vec<String>,
@@ -27,6 +28,7 @@ pub async fn route(
     let response = RootResponse {
         name: env!("CARGO_PKG_NAME").to_string(),
         version: env!("CARGO_PKG_VERSION").to_string(),
+        revision: env!("GIT_REVISION").to_string(),
         node_info,
         healthy: errors.is_empty(),
         errors,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,7 +22,10 @@ fn should_skip_serializng_fields<T>(_: &T) -> bool {
 }
 
 #[derive(Parser, Debug, Serialize)]
-#[command(author, version, about, long_about = None)]
+#[command(author,
+          version = concat!(env!("CARGO_PKG_VERSION"), " (", env!("GIT_REVISION"), ")"),
+          about,
+          long_about = None)]
 #[config]
 pub struct Args {
     #[arg(long, default_value = "0.0.0.0")]


### PR DESCRIPTION
## Context

The PR is split into these 3 commits for ease of review:

* When investigating the latest release on multiple machines, it would’ve been very handy to know which Git revision each build was prepared from. After this PR, we report it both under `--version` and `GET /`.

* I also set `meta.mainProgram` on the Nix packages – I noticed warnings when using `lib.getExe` on my home server.

* And, while at it, I removed a few explicit `"blockfrost-platform"` strings – let’s reuse the name from `Cargo.toml`.

## Examples

```
❯ ./result/bin/blockfrost-platform --version
blockfrost-platform 0.0.1 (c4c765a777b3575358fe53cc38e5358cb1ff773f)
```

```
❯ curl -fsSL http://0:3000 | jq .
{
  "name": "blockfrost-platform",
  "version": "0.0.1",
  "revision": "c4c765a777b3575358fe53cc38e5358cb1ff773f",
  "healthy": true,
  "node_info": {
    "block": "c8b522703e2953761c9e364ad66c66acaca603a90e7ad4a1c0fffb50ddf7d629",
    "epoch": 848,
    "era": 6,
    "slot": 73323955,
    "sync_progress": 100.0
  },
  "errors": []
}
```