### PR TITLE
chore: remove `testgen-hs` from production packages

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,7 +68,6 @@ jobs:
         run: |
           mkdir -p artifacts
           cp target/release/blockfrost-platform* artifacts/
-          cp -r testgen-hs artifacts/
 
       - name: Upload artifacts
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.upload_artifacts == 'true'

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,6 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
     ls -l ; cargo chef prepare --recipe-path recipe.json
 
-FROM base AS downloader
-ADD https://github.com/input-output-hk/testgen-hs/releases/download/10.1.4.2/testgen-hs-10.1.4.2-x86_64-linux.tar.bz2 /app/
-RUN tar -xjf testgen-hs-*.tar.* && /app/testgen-hs/testgen-hs --version
-
 FROM base AS builder
 COPY --from=planner /app/recipe.json recipe.json
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
@@ -31,10 +27,6 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 
 FROM gcr.io/distroless/cc-debian12:dca9008b864a381b5ce97196a4d8399ac3c2fa65 AS runtime
 COPY --from=builder /app/target/release/blockfrost-platform /app/
-COPY --from=downloader /app/testgen-hs /app/testgen-hs
-
-# Set the environment variable to the path of the testgen-hs binary
-ENV TESTGEN_HS_PATH=/app/testgen-hs/testgen-hs
 
 EXPOSE 3000/tcp
 STOPSIGNAL SIGINT

--- a/nix/internal/darwin.nix
+++ b/nix/internal/darwin.nix
@@ -51,7 +51,6 @@ in
             mv $out/{${unix.packageName},lib} $out/libexec
             mkdir -p $out/bin
             ( cd $out/bin ; ln -s ../libexec/${unix.packageName} ./ ; )
-            cp -r ${bundle-testgen-hs} $out/libexec/testgen-hs
           '';
       });
 

--- a/nix/internal/linux.nix
+++ b/nix/internal/linux.nix
@@ -39,8 +39,6 @@ in
         buildCommand =
           drv.buildCommand
           + ''
-            mkdir -p $out/lib/testgen-hs
-            cp ${lib.getExe unix.testgen-hs} $out/lib/testgen-hs/
             ( cd $out ; ln -s bin/${unix.packageName} . ; )
           '';
       });

--- a/nix/internal/unix.nix
+++ b/nix/internal/unix.nix
@@ -26,7 +26,6 @@ in
       strictDeps = true;
       nativeBuildInputs = lib.optionals pkgs.stdenv.isLinux [
         pkgs.pkg-config
-        #testgen-hs
       ];
       TESTGEN_HS_PATH = lib.getExe testgen-hs; # Don’t try to download it in `build.rs`.
       buildInputs =
@@ -55,7 +54,6 @@ in
         postInstall = ''
           chmod -R +w $out
           mv $out/bin $out/libexec
-          ln -sf ${testgen-hs}/bin $out/libexec/testgen-hs
           mkdir -p $out/bin
           ln -sf $out/libexec/${packageName} $out/bin/
         '';

--- a/nix/internal/windows.nix
+++ b/nix/internal/windows.nix
@@ -120,7 +120,6 @@ in rec {
 
   bundle = pkgs.runCommandNoCC "bundle" {} ''
     mkdir -p $out
-    cp -r ${testgen-hs}/. $out/testgen-hs
     cp -r ${packageWithIcon}/. $out/.
   '';
 


### PR DESCRIPTION
Resolves #186

Stacked on top of #185 which should be merged first.

## Results

Archive sizes:

| Platform | Size before | Size now |
|----------|----------|----------|
| Windows | 46.4 MiB | 7.23 MiB |
| Linux | 16.7 MB | 7.07 MiB |
| macOS (ARM) | 47.9 MB | 2.73 MiB |
| macOS (Intel) | 18.7 MB | 2.88 MiB |
