### PR TITLE
chore: publish tagged OCI images on release

### DIFF
--- a/.github/workflows/oci-image.yaml
+++ b/.github/workflows/oci-image.yaml
@@ -1,6 +1,11 @@
 name: OCI
+
 on:
   push:
+  release:
+    types:
+      - published
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -16,7 +21,14 @@ jobs:
       - name: 🚀 Build the image
         run: |
           docker compose build --build-arg GIT_REVISION=$(git rev-parse @)
-      - name: 📤 Push the image
+      - name: 📤 Push the image (latest)
         if: github.ref == 'refs/heads/main'
         run: |
           docker push ghcr.io/blockfrost/blockfrost-platform:latest
+      - name: 📤 Push the image (release)
+        if: github.event_name == 'release' && github.event.action == 'published'
+        run: |
+          docker push ghcr.io/blockfrost/blockfrost-platform:latest
+          docker tag  ghcr.io/blockfrost/blockfrost-platform:latest \
+                      ghcr.io/blockfrost/blockfrost-platform:${{ github.event.release.tag_name }}
+          docker push ghcr.io/blockfrost/blockfrost-platform:${{ github.event.release.tag_name }}


### PR DESCRIPTION
## Context

We didn’t have this the last time, and I had to manually tag & [publish to GHCR](https://github.com/blockfrost/blockfrost-platform/pkgs/container/blockfrost-platform/355296410?tag=0.0.1).

See [this Slack thread](https://input-output-rnd.slack.com/archives/C07FD0DNEMQ/p1739466955418789?thread_ts=1739378737.982579&cid=C07FD0DNEMQ) for more context.

