### PR TITLE
chore: rename OCI tags: `edge` is nightly, `latest` is release

### DIFF
--- a/.github/workflows/oci-image.yaml
+++ b/.github/workflows/oci-image.yaml
@@ -21,14 +21,17 @@ jobs:
       - name: 🚀 Build the image
         run: |
           docker compose build --build-arg GIT_REVISION=$(git rev-parse @)
-      - name: 📤 Push the image (latest)
+      - name: 📤 Push the image (edge)
         if: github.ref == 'refs/heads/main'
         run: |
-          docker push ghcr.io/blockfrost/blockfrost-platform:latest
-      - name: 📤 Push the image (release)
+          image=ghcr.io/blockfrost/blockfrost-platform
+          docker push $image:edge
+      - name: 📤 Push the image (release, latest)
         if: github.event_name == 'release' && github.event.action == 'published'
         run: |
-          docker push ghcr.io/blockfrost/blockfrost-platform:latest
-          docker tag  ghcr.io/blockfrost/blockfrost-platform:latest \
-                      ghcr.io/blockfrost/blockfrost-platform:${{ github.event.release.tag_name }}
-          docker push ghcr.io/blockfrost/blockfrost-platform:${{ github.event.release.tag_name }}
+          image=ghcr.io/blockfrost/blockfrost-platform
+          docker push $image:edge
+          docker tag  $image:edge $image:${{ github.event.release.tag_name }}
+          docker tag  $image:edge $image:latest
+          docker push $image:${{ github.event.release.tag_name }}
+          docker push $image:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       init-node:
         condition: service_completed_successfully
   blockfrost-platform:
-    image: ghcr.io/blockfrost/blockfrost-platform:latest
+    image: ghcr.io/blockfrost/blockfrost-platform:edge
     build:
       context: ./
       target: runtime
@@ -49,7 +49,7 @@ services:
       - --node-socket-path
       - /ipc/node.socket
   blockfrost-platform-solitary:
-    image: ghcr.io/blockfrost/blockfrost-platform:latest
+    image: ghcr.io/blockfrost/blockfrost-platform:edge
     build:
       context: ./
       target: runtime


### PR DESCRIPTION
## Context

Just a suggestion, but it’s inline with what other orgs are doing, e.g. Alpine. And a more stable experience for users that want to always have `latest`, but not necessarily bleeding edge.

If we agree to this, I’ll manually move [`latest`](https://github.com/blockfrost/blockfrost-platform/pkgs/container/blockfrost-platform/361431820?tag=latest) to point to [`0.0.1`](https://github.com/blockfrost/blockfrost-platform/pkgs/container/blockfrost-platform/355296410?tag=0.0.1) on GHCR.