### PR TITLE
chore: add missing OCI `LABEL`s, as reported by GHCR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,14 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 FROM gcr.io/distroless/cc-debian12:dca9008b864a381b5ce97196a4d8399ac3c2fa65 AS runtime
 COPY --from=builder /app/target/release/blockfrost-platform /app/
 
+ARG GIT_REVISION
+LABEL org.opencontainers.image.title="Blockfrost platform" \
+      org.opencontainers.image.url="https://platform.blockfrost.io/" \
+      org.opencontainers.image.description="The Blockfrost platform transforms your Cardano node infrastructure into a high-performance JSON API endpoint." \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.source="https://github.com/blockfrost/blockfrost-platform" \
+      org.opencontainers.image.revision=$GIT_REVISION
+
 EXPOSE 3000/tcp
 STOPSIGNAL SIGINT
 ENTRYPOINT ["/app/blockfrost-platform"]


### PR DESCRIPTION
## Context

You can see GHCR / GitHub Packages complaining here:
* https://github.com/blockfrost/blockfrost-platform/pkgs/container/blockfrost-platform/355296410?tag=0.0.1
* https://github.com/orgs/blockfrost/packages/container/blockfrost-platform/settings

Here's the standard for reference:
* https://github.com/opencontainers/image-spec/blob/main/annotations.md