### PR TITLE
chore: add SHA-256 checksums to the Curl-Bash installer

### DIFF
--- a/nix/internal/unix.nix
+++ b/nix/internal/unix.nix
@@ -216,6 +216,14 @@ in
         shortRev = inputs.self.shortRev or "dirty";
         baseUrl = releaseBaseUrl;
       } ''
+        sha256_x86_64_linux=$(sha256sum ${inputs.self.hydraJobs.archive.x86_64-linux}/*.tar.* | cut -d' ' -f1)
+        sha256_x86_64_darwin=$(sha256sum ${inputs.self.hydraJobs.archive.x86_64-darwin}/*.tar.* | cut -d' ' -f1)
+        sha256_aarch64_darwin=$(sha256sum ${inputs.self.hydraJobs.archive.aarch64-darwin}/*.tar.* | cut -d' ' -f1)
+
+        export sha256_x86_64_linux
+        export sha256_x86_64_darwin
+        export sha256_aarch64_darwin
+
         mkdir -p $out
         substituteAll ${./curl-bash-install.sh} $out/curl-bash-install.sh
         chmod +x $out/*.sh


### PR DESCRIPTION
Resolves #145

## Context

See #145 for the reasoning.

## Testing

I tested it via [michalrus/bfp-release-testing](https://github.com/michalrus/bfp-release-testing/releases/tag/0.0.1), you can see that this [`curl-bash-install.sh` file there](https://github.com/michalrus/bfp-release-testing/releases/download/0.0.1/curl-bash-install.sh) contains the hashes:

```bash
❯ curl -fsSL https://github.com/michalrus/bfp-release-testing/releases/download/0.0.1/curl-bash-install.sh \
    | grep 'expected_sha256='

  expected_sha256="0b1bcd7d3479859dd927c92dccdba15e41208a14c69c752be5c8c7d621a4daac"
  expected_sha256="d1dad2c70933a03342df9a92150be9c448f8b6c770ddde1381c68690e2f00d94"
  expected_sha256="16a0317df3bb51d55708c5084bb8a335db99486d24061bd33611f3f24573377b"
  expected_sha256="16a0317df3bb51d55708c5084bb8a335db99486d24061bd33611f3f24573377b"
```

The file itself doesn’t work OOTB, because it links to [our real 0.0.1 release](https://github.com/blockfrost/blockfrost-platform/releases/download/0.0.1), and the hashes don’t match it (they’re generated for the Git revision which runs the release).

But I tested it modifying URL to `http://localhost:12345` in a downloaded `curl-bash-install.sh`, and it does install, and work both on Linux, and macOS.