### PR TITLE
chore: silence a lot of peer selection spam & expose `cardano-submit-api`

### DIFF
--- a/nix/devshells.nix
+++ b/nix/devshells.nix
@@ -33,6 +33,10 @@ in {
       package = internal.cardano-cli;
     }
     {
+      name = "cardano-submit-api";
+      package = internal.cardano-submit-api;
+    }
+    {
       name = "cardano-address";
       package = internal.cardano-address;
     }

--- a/nix/internal/unix.nix
+++ b/nix/internal/unix.nix
@@ -120,7 +120,7 @@ in
       }
       .${targetSystem};
 
-    inherit (cardano-node-packages) cardano-node cardano-cli;
+    inherit (cardano-node-packages) cardano-node cardano-cli cardano-submit-api;
 
     cardano-node-configs-verbose = builtins.path {
       name = "cardano-playground-configs";


### PR DESCRIPTION
Two small quality-of-developer-life changes. :)

#### 461bc84fd42ed80cf0151a36314ad5dfadb7bc9b chore: silence a lot of peer selection spam in `run-node-preview`
It makes it harder to see important stuff when testing.

#### 951fe3e9085c28c3bf06361960a818362bb379a9 chore: expose `cardano-submit-api` in the devshell
I sometimes use it for testing, perhaps it’s useful to others, and we already depend on the `cardano-node` flake which includes it.