### PR TITLE
chore: use `std::net` types for IP configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Fixed
+
+- Configure local IP address to bind to with `std::net` types.
+
 ## [0.0.1] - 2025-02-13
 
 ### Added

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,14 +16,8 @@ async fn main() -> Result<(), AppError> {
     setup_tracing(config.log_level);
 
     let (app, _, icebreakers_api, api_prefix) = build(config.clone().into()).await?;
-    let address = if config.server_address.contains(':') {
-        // IPv6 address, wrap in square brackets
-        format!("[{}]:{}", config.server_address, config.server_port)
-    } else {
-        // IPv4 address, no special handling needed
-        format!("{}:{}", config.server_address, config.server_port)
-    };
-    let listener = tokio::net::TcpListener::bind(&address).await?;
+    let address = std::net::SocketAddr::new(config.server_address, config.server_port);
+    let listener = tokio::net::TcpListener::bind(address).await?;
     let (ready_tx, ready_rx) = oneshot::channel();
     let shutdown_signal = async {
         let _ = signal::ctrl_c().await;

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -33,7 +33,7 @@ pub fn test_config() -> Arc<Config> {
         env::var("NODE_SOCKET_PATH").unwrap_or_else(|_| "/run/cardano-node/node.socket".into());
 
     let config = Config {
-        server_address: "0.0.0.0".into(),
+        server_address: "0.0.0.0".parse().unwrap(),
         server_port: 8080,
         log_level: LogLevel::Info.into(),
         network_magic: 2,


### PR DESCRIPTION
Related to #207, #206

## Context

Let’s use the `std::net::*` types for IP config.