### PR TITLE
chore: provide `aarch64-linux` release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
           ref="."
 
           $nixdl  result-archive-x86_64-linux      "$ref"#internal.x86_64-linux.archive
+          $nixdl  result-archive-aarch64-linux     "$ref"#internal.aarch64-linux.archive
           $nixdl  result-archive-x86_64-windows    "$ref"#internal.x86_64-windows.archive
           $nixdl  result-archive-x86_64-darwin     "$ref"#internal.x86_64-darwin.archive
           $nixdl  result-archive-aarch64-darwin    "$ref"#internal.aarch64-darwin.archive
@@ -54,6 +55,7 @@ jobs:
         with:
           files: |
             result-archive-x86_64-linux/*.tar.bz2
+            result-archive-aarch64-linux/*.tar.bz2
             result-archive-x86_64-darwin/*.tar.bz2
             result-archive-x86_64-windows/*.zip
             result-archive-aarch64-darwin/*.tar.bz2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Added
+
+- Add `aarch64-linux` builds to release artifacts and installers.
+
 ### Fixed
 
 - Configure local IP address to bind to with `std::net` types.

--- a/flake.nix
+++ b/flake.nix
@@ -40,6 +40,9 @@
         )
         // lib.genAttrs ["x86_64-windows"] (
           targetSystem: import ./nix/internal/windows.nix {inherit inputs targetSystem;}
+        )
+        // lib.genAttrs ["aarch64-linux"] (
+          targetSystem: import ./nix/internal/linux-cross-arm64.nix {inherit inputs targetSystem;}
         );
 
       systems = [
@@ -63,6 +66,7 @@
           }
           // (lib.optionalAttrs (system == "x86_64-linux") {
             default-x86_64-windows = inputs.self.internal.x86_64-windows.package;
+            default-aarch64-linux = inputs.self.internal.aarch64-linux.package;
           });
 
         devshells.default = import ./nix/devshells.nix {inherit inputs;};
@@ -97,14 +101,15 @@
       };
 
       flake.hydraJobs = let
+        crossSystems = ["x86_64-windows" "aarch64-linux"];
         allJobs = {
-          blockfrost-platform = lib.genAttrs (config.systems ++ ["x86_64-windows"]) (
+          blockfrost-platform = lib.genAttrs (config.systems ++ crossSystems) (
             targetSystem: inputs.self.internal.${targetSystem}.package
           );
           devshell = lib.genAttrs config.systems (
             targetSystem: inputs.self.devShells.${targetSystem}.default
           );
-          archive = lib.genAttrs (config.systems ++ ["x86_64-windows"]) (
+          archive = lib.genAttrs (config.systems ++ crossSystems) (
             targetSystem: inputs.self.internal.${targetSystem}.archive
           );
           installer = {

--- a/nix/internal/curl-bash-install.sh
+++ b/nix/internal/curl-bash-install.sh
@@ -16,6 +16,10 @@ case "${isa}-${kernel}" in
   target_system="x86_64-linux"
   expected_sha256="@sha256_x86_64_linux@"
   ;;
+"aarch64-Linux")
+  target_system="aarch64-linux"
+  expected_sha256="@sha256_aarch64_linux@"
+  ;;
 "x86_64-Darwin")
   target_system="x86_64-darwin"
   expected_sha256="@sha256_x86_64_darwin@"

--- a/nix/internal/linux-cross-arm64.nix
+++ b/nix/internal/linux-cross-arm64.nix
@@ -1,0 +1,93 @@
+{
+  inputs,
+  targetSystem,
+}:
+assert __elem targetSystem ["aarch64-linux"]; let
+  buildSystem = "x86_64-linux";
+  pkgs = inputs.nixpkgs.legacyPackages.${buildSystem};
+  inherit (pkgs) lib;
+in rec {
+  toolchain = with inputs.fenix.packages.${buildSystem};
+    combine [
+      minimal.rustc
+      minimal.cargo
+      targets.aarch64-unknown-linux-gnu.latest.rust-std
+    ];
+
+  craneLib = (inputs.crane.mkLib pkgs).overrideToolchain toolchain;
+
+  src = craneLib.cleanCargoSource ../../.;
+
+  pkgsCross = pkgs.pkgsCross.aarch64-multiplatform;
+
+  commonArgs = rec {
+    inherit src;
+    strictDeps = true;
+
+    CARGO_BUILD_TARGET = "aarch64-unknown-linux-gnu";
+    TARGET_CC = "${pkgsCross.stdenv.cc}/bin/${pkgsCross.stdenv.cc.targetPrefix}cc";
+
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER = TARGET_CC;
+
+    TESTGEN_HS_PATH = "unused"; # Don’t try to download it in `build.rs`.
+
+    OPENSSL_DIR = "${pkgsCross.openssl.dev}";
+    OPENSSL_LIB_DIR = "${pkgsCross.openssl.out}/lib";
+    OPENSSL_INCLUDE_DIR = "${pkgsCross.openssl.dev}/include/";
+
+    depsBuildBuild = [
+      pkgsCross.stdenv.cc
+      #pkgsCross.windows.pthreads
+    ];
+  };
+
+  # For better caching:
+  cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+
+  packageName = (craneLib.crateNameFromCargoToml {cargoToml = src + "/Cargo.toml";}).pname;
+
+  GIT_REVISION = inputs.self.rev or "dirty";
+
+  package = craneLib.buildPackage (commonArgs
+    // {
+      inherit cargoArtifacts GIT_REVISION;
+      doCheck = false;
+      postPatch = ''
+        sed -r '/^build = .*/d' -i Cargo.toml
+        rm build.rs
+      '';
+    });
+
+  archive = let
+    outFileName = "${package.pname}-${package.version}-${inputs.self.shortRev or "dirty"}-${targetSystem}.tar.bz2";
+  in
+    pkgs.runCommandNoCC "${package.pname}-archive" {} ''
+      cp -r ${bundle} ${package.pname}
+
+      mkdir -p $out
+      tar -cjvf $out/${outFileName} ${package.pname}/
+
+      # Make it downloadable from Hydra:
+      mkdir -p $out/nix-support
+      echo "file binary-dist \"$out/${outFileName}\"" >$out/nix-support/hydra-build-products
+    '';
+
+  nix-bundle-exe = import inputs.nix-bundle-exe;
+
+  # Portable directory that can be run on any modern Linux:
+  bundle =
+    (nix-bundle-exe {
+      inherit pkgs;
+      bin_dir = "bin";
+      exe_dir = "exe";
+      lib_dir = "lib";
+    } "${package}/bin/${packageName}")
+    .overrideAttrs (drv: {
+      name = packageName;
+      buildCommand =
+        drv.buildCommand
+        + ''
+          ( cd $out ; ln -s bin/${packageName} . ; )
+        '';
+    });
+}

--- a/nix/internal/unix.nix
+++ b/nix/internal/unix.nix
@@ -238,10 +238,12 @@ in
         baseUrl = releaseBaseUrl;
       } ''
         sha256_x86_64_linux=$(sha256sum ${inputs.self.hydraJobs.archive.x86_64-linux}/*.tar.* | cut -d' ' -f1)
+        sha256_aarch64_linux=$(sha256sum ${inputs.self.hydraJobs.archive.aarch64-linux}/*.tar.* | cut -d' ' -f1)
         sha256_x86_64_darwin=$(sha256sum ${inputs.self.hydraJobs.archive.x86_64-darwin}/*.tar.* | cut -d' ' -f1)
         sha256_aarch64_darwin=$(sha256sum ${inputs.self.hydraJobs.archive.aarch64-darwin}/*.tar.* | cut -d' ' -f1)
 
         export sha256_x86_64_linux
+        export sha256_aarch64_linux
         export sha256_x86_64_darwin
         export sha256_aarch64_darwin
 


### PR DESCRIPTION
Resolves #210

## Context

In #210.

## How to test

1. Go to Hydra builds of this PR → https://ci.iog.io/jobset/blockfrost-blockfrost-platform/pullrequest-213#tabs-jobs
2. Select `archive.aarch64-linux` → https://ci.iog.io/build/6937915
3. Download on an `aarch64-linux` machine.
4. Unpack & run.

```bash
❯ uname -a
Linux nixos-vm 6.1.55 #1-NixOS SMP Sat Sep 23 09:11:13 UTC 2023 aarch64 GNU/Linux

❯ wget https://ci.iog.io/build/6937915/download/1/blockfrost-platform-0.0.1-3ab3c23-aarch64-linux.tar.bz2

❯ tar -xf blockfrost-platform-0.0.1-3ab3c23-aarch64-linux.tar.bz2

❯ file ./blockfrost-platform/exe/blockfrost-platform
./blockfrost-platform/exe/blockfrost-platform: ELF 64-bit LSB pie executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter ld-linux-aarch64.so.1, for GNU/Linux 3.10.0, not stripped

❯ ./blockfrost-platform/bin/blockfrost-platform --version
blockfrost-platform 0.0.1 (3ab3c23d2ed6a00bb99689c928dc86e810e67754)
```

![image](https://github.com/user-attachments/assets/f2c3a0db-1d90-4437-aade-b2d3bb491ffb)
