### PR TITLE
chore: code-sign the Windows installer

### DIFF
--- a/.github/workflows/git-checks.yaml
+++ b/.github/workflows/git-checks.yaml
@@ -1,9 +1,9 @@
 name: Git Checks
 on: [pull_request]
 jobs:
-  block-fixup:
-    runs-on: ubuntu-20.04
+  git-checks:
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Block Fixup Commit Merge
         uses: 13rac1/block-fixup-merge-action@v2.0.0


### PR DESCRIPTION
Resolves #144

## Context

In #144.

## How to test

Here’s the new code-signed installer:

[blockfrost-platform-0.0.1-d9651c2-x86_64-windows.exe.zip](https://github.com/user-attachments/files/19076234/blockfrost-platform-0.0.1-d9651c2-x86_64-windows.exe.zip)

### Right click → Properties → Digital Signatures:

![image](https://github.com/user-attachments/assets/69341cf2-9e9a-42a1-978b-baeea7f658ae)

### When launching the installer:

![image](https://github.com/user-attachments/assets/57ecca10-05bb-4a66-8b2c-18d7f0806cef)
