### PR TITLE
fix: expose `/` and `/metrics` without the UUID prefix

### DIFF
--- a/src/middlewares/metrics.rs
+++ b/src/middlewares/metrics.rs
@@ -1,14 +1,10 @@
-use axum::extract::{MatchedPath, Request};
+use axum::extract::Request;
 use axum::middleware::Next;
 use axum::response::IntoResponse;
 use metrics::counter;
 
 pub async fn track_http_metrics(req: Request, next: Next) -> impl IntoResponse {
-    let path = if let Some(matched_path) = req.extensions().get::<MatchedPath>() {
-        matched_path.as_str().to_owned()
-    } else {
-        req.uri().path().to_owned()
-    };
+    let path = req.uri().path().to_owned();
 
     let method = req.method().clone();
     let response = next.run(req).await;


### PR DESCRIPTION
Resolves #220

## Context

In #220.

Additionally, I have also made the random prefix ignored in metrics.

We don’t currently use `MatchedPath`, which always matches the full prefix of a nested route. But we’ll need something better once we do.