### PR TITLE
Add more information to the not found error message/logs

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -115,6 +115,16 @@ impl BlockfrostError {
         }
     }
 
+    pub async fn not_found_with_uri(method: http::Method, uri: http::Uri) -> Self {
+        Self {
+            error: "Not Found".to_string(),
+            message: format!(
+                "The requested component `{uri}` has not been found for `{method}` method"
+            ),
+            status_code: 404,
+        }
+    }
+
     /// Our custom 400 error
     pub fn custom_400(message: String) -> Self {
         Self {

--- a/src/server.rs
+++ b/src/server.rs
@@ -83,7 +83,7 @@ pub async fn build(
             .layer(Extension(health_monitor))
             .layer(Extension(node_conn_pool.clone()))
             .layer(from_fn(error_middleware))
-            .fallback(BlockfrostError::not_found());
+            .fallback(BlockfrostError::not_found_with_uri);
         if metrics_enabled {
             rv = rv.layer(Extension(setup_metrics_recorder()));
         }


### PR DESCRIPTION
Resolves https://github.com/blockfrost/blockfrost-platform/issues/225 by enriching not found error log/message.

The new message looks like: `Not Found - The requested component `/testing-enriched-not-found` has not been found for `GET` method
`