### PR TITLE
fix: bind registration client socket to server_address

### DIFF
--- a/src/icebreakers_api.rs
+++ b/src/icebreakers_api.rs
@@ -40,7 +40,10 @@ impl IcebreakersAPI {
 
         match &config.icebreakers_config {
             Some(icebreakers_config) => {
-                let client = Client::new();
+                let client = Client::builder()
+                    .local_address(config.server_address)
+                    .build()
+                    .map_err(|e| AppError::Registration(format!("Registering failed: {}", e)))?;
                 let base_url = api_url.to_string();
                 let icebreakers_api = IcebreakersAPI {
                     client,


### PR DESCRIPTION
Using the same interface for the icebreaker client and server fixes issues like using IPv6 for the client but IPv4 for the server.

For example by also binding the registration client socket to `server_address`, this avoids using IPv6 (which is not supported yet) when server_address is 0.0.0.0 (or another external IPv4 address) and IPv6 is enabled on the system.

Related:
https://github.com/seanmonstar/reqwest/issues/584

Fixes #207