### PR TITLE
Handle invalid tx cbors nicer in submit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2188,7 +2188,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "pallas"
 version = "0.32.0"
-source = "git+https://github.com/blockfrost/pallas.git?rev=35990b2a1dcecf8d45801a9bb8a3514fda1482eb#35990b2a1dcecf8d45801a9bb8a3514fda1482eb"
+source = "git+https://github.com/blockfrost/pallas.git?rev=35c7b4049d22cdeb866d9f208a70622c1b41c16a#35c7b4049d22cdeb866d9f208a70622c1b41c16a"
 dependencies = [
  "pallas-addresses",
  "pallas-codec",
@@ -2205,7 +2205,7 @@ dependencies = [
 [[package]]
 name = "pallas-addresses"
 version = "0.32.0"
-source = "git+https://github.com/blockfrost/pallas.git?rev=35990b2a1dcecf8d45801a9bb8a3514fda1482eb#35990b2a1dcecf8d45801a9bb8a3514fda1482eb"
+source = "git+https://github.com/blockfrost/pallas.git?rev=35c7b4049d22cdeb866d9f208a70622c1b41c16a#35c7b4049d22cdeb866d9f208a70622c1b41c16a"
 dependencies = [
  "base58",
  "bech32 0.9.1",
@@ -2220,7 +2220,7 @@ dependencies = [
 [[package]]
 name = "pallas-codec"
 version = "0.32.0"
-source = "git+https://github.com/blockfrost/pallas.git?rev=35990b2a1dcecf8d45801a9bb8a3514fda1482eb#35990b2a1dcecf8d45801a9bb8a3514fda1482eb"
+source = "git+https://github.com/blockfrost/pallas.git?rev=35c7b4049d22cdeb866d9f208a70622c1b41c16a#35c7b4049d22cdeb866d9f208a70622c1b41c16a"
 dependencies = [
  "hex",
  "minicbor",
@@ -2231,7 +2231,7 @@ dependencies = [
 [[package]]
 name = "pallas-configs"
 version = "0.32.0"
-source = "git+https://github.com/blockfrost/pallas.git?rev=35990b2a1dcecf8d45801a9bb8a3514fda1482eb#35990b2a1dcecf8d45801a9bb8a3514fda1482eb"
+source = "git+https://github.com/blockfrost/pallas.git?rev=35c7b4049d22cdeb866d9f208a70622c1b41c16a#35c7b4049d22cdeb866d9f208a70622c1b41c16a"
 dependencies = [
  "base64 0.22.1",
  "num-rational",
@@ -2246,7 +2246,7 @@ dependencies = [
 [[package]]
 name = "pallas-crypto"
 version = "0.32.0"
-source = "git+https://github.com/blockfrost/pallas.git?rev=35990b2a1dcecf8d45801a9bb8a3514fda1482eb#35990b2a1dcecf8d45801a9bb8a3514fda1482eb"
+source = "git+https://github.com/blockfrost/pallas.git?rev=35c7b4049d22cdeb866d9f208a70622c1b41c16a#35c7b4049d22cdeb866d9f208a70622c1b41c16a"
 dependencies = [
  "cryptoxide",
  "hex",
@@ -2259,7 +2259,7 @@ dependencies = [
 [[package]]
 name = "pallas-hardano"
 version = "0.32.0"
-source = "git+https://github.com/blockfrost/pallas.git?rev=35990b2a1dcecf8d45801a9bb8a3514fda1482eb#35990b2a1dcecf8d45801a9bb8a3514fda1482eb"
+source = "git+https://github.com/blockfrost/pallas.git?rev=35c7b4049d22cdeb866d9f208a70622c1b41c16a#35c7b4049d22cdeb866d9f208a70622c1b41c16a"
 dependencies = [
  "binary-layout",
  "hex",
@@ -2279,7 +2279,7 @@ dependencies = [
 [[package]]
 name = "pallas-network"
 version = "0.32.0"
-source = "git+https://github.com/blockfrost/pallas.git?rev=35990b2a1dcecf8d45801a9bb8a3514fda1482eb#35990b2a1dcecf8d45801a9bb8a3514fda1482eb"
+source = "git+https://github.com/blockfrost/pallas.git?rev=35c7b4049d22cdeb866d9f208a70622c1b41c16a#35c7b4049d22cdeb866d9f208a70622c1b41c16a"
 dependencies = [
  "byteorder 1.5.0",
  "hex",
@@ -2296,7 +2296,7 @@ dependencies = [
 [[package]]
 name = "pallas-primitives"
 version = "0.32.0"
-source = "git+https://github.com/blockfrost/pallas.git?rev=35990b2a1dcecf8d45801a9bb8a3514fda1482eb#35990b2a1dcecf8d45801a9bb8a3514fda1482eb"
+source = "git+https://github.com/blockfrost/pallas.git?rev=35c7b4049d22cdeb866d9f208a70622c1b41c16a#35c7b4049d22cdeb866d9f208a70622c1b41c16a"
 dependencies = [
  "hex",
  "pallas-codec",
@@ -2308,7 +2308,7 @@ dependencies = [
 [[package]]
 name = "pallas-traverse"
 version = "0.32.0"
-source = "git+https://github.com/blockfrost/pallas.git?rev=35990b2a1dcecf8d45801a9bb8a3514fda1482eb#35990b2a1dcecf8d45801a9bb8a3514fda1482eb"
+source = "git+https://github.com/blockfrost/pallas.git?rev=35c7b4049d22cdeb866d9f208a70622c1b41c16a#35c7b4049d22cdeb866d9f208a70622c1b41c16a"
 dependencies = [
  "hex",
  "itertools 0.13.0",
@@ -2324,7 +2324,7 @@ dependencies = [
 [[package]]
 name = "pallas-txbuilder"
 version = "0.32.0"
-source = "git+https://github.com/blockfrost/pallas.git?rev=35990b2a1dcecf8d45801a9bb8a3514fda1482eb#35990b2a1dcecf8d45801a9bb8a3514fda1482eb"
+source = "git+https://github.com/blockfrost/pallas.git?rev=35c7b4049d22cdeb866d9f208a70622c1b41c16a#35c7b4049d22cdeb866d9f208a70622c1b41c16a"
 dependencies = [
  "hex",
  "pallas-addresses",
@@ -2341,7 +2341,7 @@ dependencies = [
 [[package]]
 name = "pallas-utxorpc"
 version = "0.32.0"
-source = "git+https://github.com/blockfrost/pallas.git?rev=35990b2a1dcecf8d45801a9bb8a3514fda1482eb#35990b2a1dcecf8d45801a9bb8a3514fda1482eb"
+source = "git+https://github.com/blockfrost/pallas.git?rev=35c7b4049d22cdeb866d9f208a70622c1b41c16a#35c7b4049d22cdeb866d9f208a70622c1b41c16a"
 dependencies = [
  "pallas-codec",
  "pallas-crypto",
@@ -2355,7 +2355,7 @@ dependencies = [
 [[package]]
 name = "pallas-validate"
 version = "0.32.0"
-source = "git+https://github.com/blockfrost/pallas.git?rev=35990b2a1dcecf8d45801a9bb8a3514fda1482eb#35990b2a1dcecf8d45801a9bb8a3514fda1482eb"
+source = "git+https://github.com/blockfrost/pallas.git?rev=35c7b4049d22cdeb866d9f208a70622c1b41c16a#35c7b4049d22cdeb866d9f208a70622c1b41c16a"
 dependencies = [
  "chrono",
  "hex",
@@ -2373,7 +2373,7 @@ dependencies = [
 [[package]]
 name = "pallas-wallet"
 version = "0.32.0"
-source = "git+https://github.com/blockfrost/pallas.git?rev=35990b2a1dcecf8d45801a9bb8a3514fda1482eb#35990b2a1dcecf8d45801a9bb8a3514fda1482eb"
+source = "git+https://github.com/blockfrost/pallas.git?rev=35c7b4049d22cdeb866d9f208a70622c1b41c16a#35c7b4049d22cdeb866d9f208a70622c1b41c16a"
 dependencies = [
  "bech32 0.9.1",
  "bip39",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,14 +22,14 @@ thiserror = "2.0.11"
 sentry = "0.36.0"
 blake2 = "0.10.6"
 num_cpus = "1"
-pallas = { git = "https://github.com/blockfrost/pallas.git", rev = "35990b2a1dcecf8d45801a9bb8a3514fda1482eb" }
-pallas-network = { git = "https://github.com/blockfrost/pallas.git", rev = "35990b2a1dcecf8d45801a9bb8a3514fda1482eb" }
-pallas-crypto = { git = "https://github.com/blockfrost/pallas.git", rev = "35990b2a1dcecf8d45801a9bb8a3514fda1482eb" }
-pallas-traverse = { git = "https://github.com/blockfrost/pallas.git", rev = "35990b2a1dcecf8d45801a9bb8a3514fda1482eb" }
-pallas-codec = { git = "https://github.com/blockfrost/pallas.git", rev = "35990b2a1dcecf8d45801a9bb8a3514fda1482eb" }
-pallas-addresses = { git = "https://github.com/blockfrost/pallas.git", rev = "35990b2a1dcecf8d45801a9bb8a3514fda1482eb" }
-pallas-primitives = { git = "https://github.com/blockfrost/pallas.git", rev = "35990b2a1dcecf8d45801a9bb8a3514fda1482eb" }
-pallas-hardano = { git = "https://github.com/blockfrost/pallas.git", rev = "35990b2a1dcecf8d45801a9bb8a3514fda1482eb" }
+pallas = { git = "https://github.com/blockfrost/pallas.git", rev = "35c7b4049d22cdeb866d9f208a70622c1b41c16a" }
+pallas-network = { git = "https://github.com/blockfrost/pallas.git", rev = "35c7b4049d22cdeb866d9f208a70622c1b41c16a" }
+pallas-crypto = { git = "https://github.com/blockfrost/pallas.git", rev = "35c7b4049d22cdeb866d9f208a70622c1b41c16a" }
+pallas-traverse = { git = "https://github.com/blockfrost/pallas.git", rev = "35c7b4049d22cdeb866d9f208a70622c1b41c16a" }
+pallas-codec = { git = "https://github.com/blockfrost/pallas.git", rev = "35c7b4049d22cdeb866d9f208a70622c1b41c16a" }
+pallas-addresses = { git = "https://github.com/blockfrost/pallas.git", rev = "35c7b4049d22cdeb866d9f208a70622c1b41c16a" }
+pallas-primitives = { git = "https://github.com/blockfrost/pallas.git", rev = "35c7b4049d22cdeb866d9f208a70622c1b41c16a" }
+pallas-hardano = { git = "https://github.com/blockfrost/pallas.git", rev = "35c7b4049d22cdeb866d9f208a70622c1b41c16a" }
 
 reqwest = "0.12.12"
 hex = "0.4.3"

--- a/src/node/transactions.rs
+++ b/src/node/transactions.rs
@@ -1,12 +1,13 @@
 use super::connection::NodeClient;
 use crate::BlockfrostError;
 use pallas_crypto::hash::Hasher;
-use pallas_hardano::display::haskell_error::as_node_submit_error;
+use pallas_hardano::display::haskell_error::{as_cbor_decode_failure, as_node_submit_error};
 use pallas_network::miniprotocols::{
     localstate,
     localtxsubmission::{EraTx, Response},
 };
-use tracing::info;
+use pallas_primitives::conway::Tx;
+use tracing::{debug, info};
 
 impl NodeClient {
     /// Submits a transaction to the connected Cardano node.
@@ -16,6 +17,8 @@ impl NodeClient {
     /// * Swagger: <https://github.com/IntersectMBO/cardano-node/blob/6e969c6bcc0f07bd1a69f4d76b85d6fa9371a90b/cardano-submit-api/swagger.yaml#L52>
     /// * Haskell code: <https://github.com/IntersectMBO/cardano-node/blob/6e969c6bcc0f07bd1a69f4d76b85d6fa9371a90b/cardano-submit-api/src/Cardano/TxSubmit/Web.hs#L158>
     pub async fn submit_transaction(&mut self, tx: Vec<u8>) -> Result<String, BlockfrostError> {
+        Self::assert_valid_tx_cbor(&tx)?;
+
         let txid = hex::encode(Hasher::<256>::hash_cbor(&tx));
 
         let current_era = self
@@ -44,9 +47,52 @@ impl NodeClient {
             },
             Err(e) => {
                 let error_message = format!("Error during transaction submission: {:?}", e);
-
                 Err(BlockfrostError::custom_400(error_message))
             },
         }
+    }
+
+    fn assert_valid_tx_cbor(tx: &[u8]) -> Result<(), BlockfrostError> {
+        match pallas_codec::minicbor::decode::<Tx>(tx) {
+            Ok(_) => Ok(()),
+            Err(e) => {
+                debug!("Invalid TX CBOR submitted: {:?}", e);
+                Err(BlockfrostError::custom_400(as_cbor_decode_failure(
+                    e.to_string(),
+                    e.position().unwrap_or(0) as u64,
+                )))
+            },
+        }
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_assert_valid_tx_cbor() {
+        // Invalid CBOR bytes
+        let invalid_tx = vec![0xFF, 0xFF];
+        assert!(NodeClient::assert_valid_tx_cbor(&invalid_tx).is_err());
+
+        let invalid_tx = "aaaaaa".as_bytes().to_vec();
+        assert!(NodeClient::assert_valid_tx_cbor(&invalid_tx).is_err());
+
+        let invalid_tx = "8".as_bytes().to_vec();
+        assert!(NodeClient::assert_valid_tx_cbor(&invalid_tx).is_err());
+
+        let invalid_tx = "821".as_bytes().to_vec();
+        assert!(NodeClient::assert_valid_tx_cbor(&invalid_tx).is_err());
+        // Empty bytes
+        let empty_tx = vec![];
+        assert!(NodeClient::assert_valid_tx_cbor(&empty_tx).is_err());
+
+        let invalid_tx = "".as_bytes().to_vec();
+        assert!(NodeClient::assert_valid_tx_cbor(&invalid_tx).is_err());
+
+        // Sample valid CBOR bytes representing a minimal TransactionBody
+        // This is a very basic transaction body encoded as CBOR
+        let valid_tx = hex::decode("84a300d90102818258205176274bef11d575edd6aa72392aaf993a07f736e70239c1fb22d4b1426b22bc01018282583900ddf1eb9ce2a1561e8f156991486b97873fb6969190cbc99ddcb3816621dcb03574152623414ed354d2d8f50e310f3f2e7d167cb20e5754271a003d09008258390099a5cb0fa8f19aba38cacf8a243d632149129f882df3a8e67f6bd512bcb0cde66a545e9fbc7ca4492f39bca1f4f265cc1503b4f7d6ff205c1b000000024f127a7c021a0002a2ada100d90102818258208b83e59abc9d7a66a77be5e0825525546a595174f8b929f164fcf5052d7aab7b5840709c64556c946abf267edd90b8027343d065193ef816529d8fa7aa2243f1fd2ec27036a677974199e2264cb582d01925134b9a20997d5a734da298df957eb002f5f6").unwrap();
+        assert!(NodeClient::assert_valid_tx_cbor(&valid_tx).is_ok());
     }
 }


### PR DESCRIPTION
Please note that this errors are not word to word identical to the Haskell implementation. In my opinion It should be fine like this.

The specific different error message comes from the language's implementation of serializers.

Haskell:
`DecoderErrorDeserialiseFailure \"Shelley Tx\" (DeserialiseFailure 0 (\"expected list len or indef\"))`

Rust:
`DecoderErrorDeserialiseFailure \"Shelley Tx\" (DeserialiseFailure 0 (\"unexpected type map at position 0: expected array\"))`