### PR TITLE
chore: use the `counter` type not `gauge` for monotonic metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 
+- Node connection metrics inconsistency caused by an initialization timing issue.
 - Configure local IP address to bind to with `std::net` types.
 
 ## [0.0.1] - 2025-02-13

--- a/src/api/metrics.rs
+++ b/src/api/metrics.rs
@@ -1,6 +1,6 @@
 use crate::BlockfrostError;
 use axum::response::{Extension, IntoResponse};
-use metrics::{describe_counter, describe_gauge, gauge};
+use metrics::{counter, describe_counter, describe_gauge, gauge};
 use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
 use std::sync::{Arc, OnceLock};
 use tokio::sync::RwLock;
@@ -39,29 +39,29 @@ fn internal_setup() -> Arc<RwLock<PrometheusHandle>> {
     );
     gauge!("cardano_node_connections").set(0);
 
-    describe_gauge!(
+    describe_counter!(
         "cardano_node_connections_initiated",
         "Number of Cardano node N2C connections that have ever been initiated"
     );
-    gauge!("cardano_node_connections_initiated").set(0);
+    counter!("cardano_node_connections_initiated").absolute(0);
 
-    describe_gauge!(
+    describe_counter!(
         "cardano_node_connections_failed",
         "Number of Cardano node N2C connections that failed and had to be restarted"
     );
-    gauge!("cardano_node_connections_failed").set(0);
+    counter!("cardano_node_connections_failed").absolute(0);
 
-    describe_gauge!(
+    describe_counter!(
         "tx_submit_success",
         "Number of transactions that were successfully submitted"
     );
-    gauge!("tx_submit_success").set(0);
+    counter!("tx_submit_success").absolute(0);
 
-    describe_gauge!(
+    describe_counter!(
         "tx_submit_failure",
         "Number of transactions that were submitted with an error"
     );
-    gauge!("tx_submit_failure").set(0);
+    counter!("tx_submit_failure").absolute(0);
 
     Arc::new(RwLock::new(builder))
 }

--- a/src/api/tx_submit.rs
+++ b/src/api/tx_submit.rs
@@ -1,6 +1,6 @@
 use crate::{BlockfrostError, NodePool, common::validate_content_type};
 use axum::{Extension, Json, http::HeaderMap, response::IntoResponse};
-use metrics::gauge;
+use metrics::counter;
 
 pub async fn route(
     Extension(node): Extension<NodePool>,
@@ -20,9 +20,9 @@ pub async fn route(
         let response = node.submit_transaction(binary_tx).await;
 
         if response.is_ok() {
-            gauge!("tx_submit_success").increment(1)
+            counter!("tx_submit_success").increment(1)
         } else {
-            gauge!("tx_submit_failure").increment(1)
+            counter!("tx_submit_failure").increment(1)
         }
 
         response

--- a/src/node/pool_manager.rs
+++ b/src/node/pool_manager.rs
@@ -1,7 +1,7 @@
 use super::connection::NodeClient;
 use crate::AppError;
 use deadpool::managed::{Manager, Metrics, RecycleError, RecycleResult};
-use metrics::gauge;
+use metrics::{counter, gauge};
 use pallas_network::facades::NodeClient as NodeClientFacade;
 use tracing::{error, info};
 
@@ -17,7 +17,7 @@ impl Manager for NodePoolManager {
     async fn create(&self) -> Result<NodeClient, AppError> {
         // TODO: maybe use `ExponentialBackoff` from `tokio-retry`, to have at
         // least _some_ debouncing between requests, if the node is down?
-        gauge!("cardano_node_connections_initiated").increment(1);
+        counter!("cardano_node_connections_initiated").increment(1);
 
         match NodeClientFacade::connect(&self.socket_path, self.network_magic).await {
             Ok(connection) => {
@@ -32,7 +32,7 @@ impl Manager for NodePoolManager {
                 })
             },
             Err(err) => {
-                gauge!("cardano_node_connections_failed").increment(1);
+                counter!("cardano_node_connections_failed").increment(1);
                 error!(
                     "Failed to connect a node socket: {}: {:?}",
                     self.socket_path,
@@ -64,7 +64,7 @@ impl Manager for NodePoolManager {
                 // I should not be used again.
                 let owned = node.client.take().unwrap();
 
-                gauge!("cardano_node_connections_failed").increment(1);
+                counter!("cardano_node_connections_failed").increment(1);
                 gauge!("cardano_node_connections").decrement(1);
 
                 // Now call `abort` to clean up their resources:


### PR DESCRIPTION
## Context

A really minor thing, but let’s use the `counter` type for monotonic (only ever increasing) _counters_.

Gauges can go both ways – they have both `.increase()` / `.decrease()`.

It’s also a useful hint to the end user setting up a Grafana dashboard for themselves, compare:

```
# TYPE cardano_node_connections_initiated counter
cardano_node_connections_initiated 38

# TYPE cardano_node_connections_failed counter
cardano_node_connections_failed 37

# TYPE cardano_node_connections gauge
cardano_node_connections 1
```