### PR TITLE
fix: invalidate N2C connections on more serious errors

### DIFF
--- a/src/node/connection.rs
+++ b/src/node/connection.rs
@@ -11,6 +11,8 @@ pub struct NodeClient {
     /// *always* [`Some`]. See [`<super::pool_manager::NodePoolManager as
     /// deadpool::managed::Manager>>::recycle`] for an explanation.
     pub(in crate::node) client: Option<NodeClientFacade>,
+    pub(in crate::node) connection_id: u64,
+    pub(in crate::node) unrecoverable_error_happened: bool,
 }
 
 impl NodeClient {
@@ -31,23 +33,30 @@ impl NodeClient {
         // Acquire the client
         let client = self.client.as_mut().unwrap().statequery();
 
-        client
-            .acquire(None)
-            .await
-            .inspect_err(|e| error!("Failed to acquire a statequery client: {:?}", e))?;
+        client.acquire(None).await.inspect_err(|e| {
+            error!(
+                "N2C[{}]: failed to acquire a statequery client: {:?}",
+                self.connection_id, e
+            )
+        })?;
 
         // Run the action with a timeout
         let result = timeout(duration, action(client)).await.map_err(|_| {
             let msg = format!("Timeout after {} seconds", duration.as_secs());
-            error!("{} in with_statequery_timeout", msg);
+            error!(
+                "N2C[{}]: {} in with_statequery_timeout",
+                self.connection_id, msg
+            );
             BlockfrostError::timeout(msg)
         })?;
 
         // Always release the client, even if action fails
-        client
-            .send_release()
-            .await
-            .inspect_err(|e| error!("Failed to release a statequery client: {:?}", e))?;
+        client.send_release().await.inspect_err(|e| {
+            error!(
+                "N2C[{}]: failed to release a statequery client: {:?}",
+                self.connection_id, e
+            )
+        })?;
 
         result
     }
@@ -73,5 +82,15 @@ impl NodeClient {
 
         self.with_statequery_timeout(|_| Box::pin(async { Ok(()) }), Duration::from_secs(30))
             .await
+    }
+
+    /// After you call this, the pool will never use this N2C connection again.
+    /// The need to do this arises rarely in normal operation, but it happens.
+    pub fn invalidate_connection(&mut self, why: &str) {
+        error!(
+            "N2C[{}]: connection marked as invalid: {}",
+            self.connection_id, why
+        );
+        self.unrecoverable_error_happened = true;
     }
 }

--- a/src/node/pool_manager.rs
+++ b/src/node/pool_manager.rs
@@ -3,12 +3,15 @@ use crate::AppError;
 use deadpool::managed::{Manager, Metrics, RecycleError, RecycleResult};
 use metrics::{counter, gauge};
 use pallas_network::facades::NodeClient as NodeClientFacade;
+use std::sync::atomic;
 use tracing::{error, info};
 
 pub struct NodePoolManager {
     pub network_magic: u64,
     pub socket_path: String,
 }
+
+static N2C_CONNECTION_COUNTER: atomic::AtomicU64 = atomic::AtomicU64::new(0);
 
 impl Manager for NodePoolManager {
     type Type = NodeClient;
@@ -18,23 +21,27 @@ impl Manager for NodePoolManager {
         // TODO: maybe use `ExponentialBackoff` from `tokio-retry`, to have at
         // least _some_ debouncing between requests, if the node is down?
         counter!("cardano_node_connections_initiated").increment(1);
+        let connection_id = 1 + N2C_CONNECTION_COUNTER.fetch_add(1, atomic::Ordering::SeqCst);
 
         match NodeClientFacade::connect(&self.socket_path, self.network_magic).await {
             Ok(connection) => {
                 info!(
-                    "N2C connection to node was successfully established at socket: {}",
-                    self.socket_path
+                    "N2C[{}]: connection successfully established with a node socket: {}",
+                    connection_id, self.socket_path
                 );
                 gauge!("cardano_node_connections").increment(1);
 
                 Ok(NodeClient {
                     client: Some(connection),
+                    connection_id,
+                    unrecoverable_error_happened: false,
                 })
             },
             Err(err) => {
                 counter!("cardano_node_connections_failed").increment(1);
                 error!(
-                    "Failed to connect a node socket: {}: {:?}",
+                    "N2C[{}]: failed to connect to a node socket: {}: {:?}",
+                    connection_id,
                     self.socket_path,
                     err.to_string()
                 );
@@ -50,13 +57,23 @@ impl Manager for NodePoolManager {
     /// have to call [`pallas_network::facades::NodeClient::abort`], because it
     /// joins certain multiplexer threads. Otherwise, it’s a resource leak.
     async fn recycle(&self, node: &mut NodeClient, metrics: &Metrics) -> RecycleResult<AppError> {
+        let can_communicate = if node.unrecoverable_error_happened {
+            Err(AppError::Node(
+                "unrecoverable error happened previously".to_string(),
+            ))
+        } else {
+            node.ping()
+                .await
+                .map_err(|err| AppError::Node(err.to_string()))
+        };
+
         // Check if the connection is still viable
-        match node.ping().await {
+        match can_communicate {
             Ok(_) => Ok(()),
             Err(err) => {
                 error!(
-                    "N2C connection no longer viable: {}, {}, {:?}",
-                    self.socket_path, err, metrics
+                    "N2C[{}]: connection no longer viable: {}, {}, {:?}",
+                    node.connection_id, self.socket_path, err, metrics
                 );
 
                 // Take ownership of the `NodeClient` from Pallas
@@ -71,7 +88,7 @@ impl Manager for NodePoolManager {
                 owned.abort().await;
 
                 // And scrap the connection from the pool:
-                Err(RecycleError::Backend(AppError::Node(err.to_string())))
+                Err(RecycleError::Backend(err))
             },
         }
     }

--- a/src/node/transactions.rs
+++ b/src/node/transactions.rs
@@ -37,16 +37,23 @@ impl NodeClient {
         // Submit the transaction
         match submission_client.submit_tx(era_tx).await {
             Ok(Response::Accepted) => {
-                info!("Transaction accepted by the node {}", txid);
+                info!(
+                    "N2C[{}]: Transaction accepted by the node: {}",
+                    self.connection_id, txid
+                );
                 Ok(txid)
             },
             Ok(Response::Rejected(reason)) => {
                 let haskell_display = as_node_submit_error(reason);
-                info!("{}: {:?}", "TxSubmitFail", haskell_display);
+                info!(
+                    "N2C[{}]: {}: {:?}",
+                    self.connection_id, "TxSubmitFail", haskell_display
+                );
                 Err(BlockfrostError::custom_400(haskell_display))
             },
             Err(e) => {
                 let error_message = format!("Error during transaction submission: {:?}", e);
+                self.invalidate_connection(&error_message); // Never use this connection again.
                 Err(BlockfrostError::custom_400(error_message))
             },
         }


### PR DESCRIPTION
Related to #238 

## Context

On my server this happened overnight:

```
Mar 19 04:24:12 monstrum blockfrost-platform[1515427]: 2025-03-19T04:24:12.911480Z ERROR err=Error { err: Overflow(58843353900), pos: Some(705), msg: "when converting u64 to i32" }
Mar 19 04:24:12 monstrum blockfrost-platform[1515427]: 2025-03-19T04:24:12.911565Z ERROR Error occurred: Bad Request - Error during transaction submission: ChannelError(Decoding("58843353900 overflows target type at position 705: when converting u64 to i32"))
```

And each subsequent submission resulted in `AgencyIsTheirs`:

```
Mar 19 04:24:34 monstrum blockfrost-platform[1515427]: 2025-03-19T04:24:34.037194Z ERROR Error occurred: Bad Request - Error during transaction submission: AgencyIsTheirs
Mar 19 04:24:55 monstrum blockfrost-platform[1515427]: 2025-03-19T04:24:55.982171Z ERROR Error occurred: Bad Request - Error during transaction submission: AgencyIsTheirs
Mar 19 04:25:17 monstrum blockfrost-platform[1515427]: 2025-03-19T04:25:17.725352Z ERROR Error occurred: Bad Request - Error during transaction submission: AgencyIsTheirs
Mar 19 04:25:40 monstrum blockfrost-platform[1515427]: 2025-03-19T04:25:40.647962Z ERROR Error occurred: Bad Request - Error during transaction submission: AgencyIsTheirs
Mar 19 04:26:02 monstrum blockfrost-platform[1515427]: 2025-03-19T04:26:02.645199Z ERROR Error occurred: Bad Request - Error during transaction submission: AgencyIsTheirs
Mar 19 04:26:24 monstrum blockfrost-platform[1515427]: 2025-03-19T04:26:24.232559Z ERROR Error occurred: Bad Request - Error during transaction submission: AgencyIsTheirs
Mar 19 04:26:47 monstrum blockfrost-platform[1515427]: 2025-03-19T04:26:47.447750Z ERROR Error occurred: Bad Request - Error during transaction submission: AgencyIsTheirs
Mar 19 04:27:09 monstrum blockfrost-platform[1515427]: 2025-03-19T04:27:09.854261Z ERROR Error occurred: Bad Request - Error during transaction submission: AgencyIsTheirs
Mar 19 04:27:31 monstrum blockfrost-platform[1515427]: 2025-03-19T04:27:31.727655Z ERROR Error occurred: Bad Request - Error during transaction submission: AgencyIsTheirs
Mar 19 04:27:53 monstrum blockfrost-platform[1515427]: 2025-03-19T04:27:53.772375Z ERROR Error occurred: Bad Request - Error during transaction submission: AgencyIsTheirs
Mar 19 04:28:15 monstrum blockfrost-platform[1515427]: 2025-03-19T04:28:15.118482Z ERROR Error occurred: Bad Request - Error during transaction submission: AgencyIsTheirs
Mar 19 04:28:37 monstrum blockfrost-platform[1515427]: 2025-03-19T04:28:37.374259Z ERROR Error occurred: Bad Request - Error during transaction submission: AgencyIsTheirs
Mar 19 04:28:58 monstrum blockfrost-platform[1515427]: 2025-03-19T04:28:58.807360Z ERROR Error occurred: Bad Request - Error during transaction submission: AgencyIsTheirs
```

This is because the ping (the `localstate` miniprotocol) over the N2C connection works, so the whole connection is assumed to be in a correct state, but the `submission` miniprotocol is not.

## Solution

* Invalidate the connection on transaction submission _server_ errors that happen rarely.

* Client errors, i.e. logically invalid transactions are still good.

* I also added a connection counter, and am logging it to ease debugging of interleaved connections.

## Rejected impossible solution

It would be best to check whether the connection is in a fresh state in the pool manager, but unfortunately Pallas’ `has_agency()` functions are not public:

* https://github.com/txpipe/pallas/blob/2ddb5b066bbde9d2ed55014b286f47ad370b828e/pallas-network/src/miniprotocols/localtxsubmission/client.rs#L72-L73