### PR TITLE
chore: expose process metrics (memory, CPU time, fds, threads)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- Expose process metrics (memory, CPU time, fds, threads)
 - Add more logs and finer details to `NodeClient::submit_transaction`
 - Header `blockfrost-platform-response` in `tx_submit` endpoint
 - Add `aarch64-linux` builds to release artifacts and installers.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,6 +259,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+dependencies = [
+ "bitflags 2.8.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "bip39"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -394,6 +412,7 @@ dependencies = [
  "jemalloc",
  "metrics",
  "metrics-exporter-prometheus",
+ "metrics-process",
  "num_cpus",
  "pallas",
  "pallas-addresses",
@@ -534,6 +553,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,6 +590,17 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -1763,6 +1802,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
+name = "libloading"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "libproc"
+version = "0.14.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78a09b56be5adbcad5aa1197371688dc6bb249a26da3bca2011ee2fb987ebfb"
+dependencies = [
+ "bindgen",
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1811,6 +1871,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
+name = "mach2"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1853,6 +1922,22 @@ dependencies = [
  "metrics-util",
  "quanta",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "metrics-process"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a82c8add4382f29a122fa64fff1891453ed0f6b2867d971e7d60cb8dfa322ff"
+dependencies = [
+ "libc",
+ "libproc",
+ "mach2",
+ "metrics",
+ "once_cell",
+ "procfs",
+ "rlimit",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -1907,6 +1992,12 @@ dependencies = [
  "quote",
  "syn 2.0.96",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1970,6 +2061,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b6b097ecb1cbfed438542d16e84fd7ad9b0c76c8a65b7f9039212a3d14dc7f"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -2587,6 +2688,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "procfs"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
+dependencies = [
+ "bitflags 2.8.0",
+ "hex",
+ "procfs-core",
+ "rustix",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
+dependencies = [
+ "bitflags 2.8.0",
+ "hex",
+]
+
+[[package]]
 name = "proptest"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2941,6 +3064,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rlimit"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7043b63bd0cd1aaa628e476b80e6d4023a3b50eb32789f2728908107bd0c793a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "rstest"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2975,6 +3107,12 @@ name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-serialize"
@@ -4284,6 +4422,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4298,9 +4446,22 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
  "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings",
  "windows-targets 0.52.6",
 ]
 
@@ -4316,10 +4477,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "windows-interface"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,12 +30,12 @@ pallas-codec = { git = "https://github.com/blockfrost/pallas.git", rev = "478fd4
 pallas-addresses = { git = "https://github.com/blockfrost/pallas.git", rev = "478fd4ab1148c0d4f8591e202220ffb9ab243b5b" }
 pallas-primitives = { git = "https://github.com/blockfrost/pallas.git", rev = "478fd4ab1148c0d4f8591e202220ffb9ab243b5b" }
 pallas-hardano = { git = "https://github.com/blockfrost/pallas.git", rev = "478fd4ab1148c0d4f8591e202220ffb9ab243b5b" }
-
 reqwest = "0.12.12"
 hex = "0.4.3"
 cbor = "0.4.1"
 metrics = { version = "0.24.1", default-features = false }
 metrics-exporter-prometheus = { version = "0.16.1", default-features = false }
+metrics-process = "2.4.0"
 chrono = "0.4"
 deadpool = "0.12.1"
 serde_with = "3.12.0"

--- a/deny.toml
+++ b/deny.toml
@@ -4,6 +4,7 @@ allow = [
   "Apache-2.0",
   "BSD-3-Clause",
   "CC0-1.0",
+  "ISC",
   "MIT",
   "Unicode-3.0",
   "MPL-2.0",

--- a/nix/devshells.nix
+++ b/nix/devshells.nix
@@ -83,12 +83,19 @@ in {
     You can now run ‘{bold}cargo run{reset}’.
   '';
 
-  env = [
-    {
-      name = "TESTGEN_HS_PATH";
-      value = lib.getExe internal.testgen-hs;
-    }
-  ];
+  env =
+    [
+      {
+        name = "TESTGEN_HS_PATH";
+        value = lib.getExe internal.testgen-hs;
+      }
+    ]
+    ++ lib.optionals pkgs.stdenv.isDarwin [
+      {
+        name = "LIBCLANG_PATH";
+        value = internal.commonArgs.LIBCLANG_PATH;
+      }
+    ];
 
   devshell.startup.symlink-configs.text = ''
     ln -sfn ${internal.cardano-node-configs} $PRJ_ROOT/cardano-node-configs

--- a/nix/internal/unix.nix
+++ b/nix/internal/unix.nix
@@ -21,24 +21,29 @@ in
 
     src = craneLib.cleanCargoSource ../../.;
 
-    commonArgs = {
-      inherit src;
-      strictDeps = true;
-      nativeBuildInputs = lib.optionals pkgs.stdenv.isLinux [
-        pkgs.pkg-config
-      ];
-      TESTGEN_HS_PATH = lib.getExe testgen-hs; # Don’t try to download it in `build.rs`.
-      buildInputs =
-        lib.optionals pkgs.stdenv.isLinux [
-          pkgs.openssl
-        ]
-        ++ lib.optionals pkgs.stdenv.isDarwin [
-          pkgs.libiconv
-          pkgs.darwin.apple_sdk_12_3.frameworks.SystemConfiguration
-          pkgs.darwin.apple_sdk_12_3.frameworks.Security
-          pkgs.darwin.apple_sdk_12_3.frameworks.CoreFoundation
+    commonArgs =
+      {
+        inherit src;
+        strictDeps = true;
+        nativeBuildInputs = lib.optionals pkgs.stdenv.isLinux [
+          pkgs.pkg-config
         ];
-    };
+        TESTGEN_HS_PATH = lib.getExe testgen-hs; # Don’t try to download it in `build.rs`.
+        buildInputs =
+          lib.optionals pkgs.stdenv.isLinux [
+            pkgs.openssl
+          ]
+          ++ lib.optionals pkgs.stdenv.isDarwin [
+            pkgs.libiconv
+            pkgs.darwin.apple_sdk_12_3.frameworks.SystemConfiguration
+            pkgs.darwin.apple_sdk_12_3.frameworks.Security
+            pkgs.darwin.apple_sdk_12_3.frameworks.CoreFoundation
+          ];
+      }
+      // lib.optionalAttrs pkgs.stdenv.isDarwin {
+        # for bindgen, used by libproc, used by metrics_process
+        LIBCLANG_PATH = "${lib.getLib pkgs.llvmPackages.libclang}/lib";
+      };
 
     # For better caching:
     cargoArtifacts = craneLib.buildDepsOnly commonArgs;

--- a/src/server.rs
+++ b/src/server.rs
@@ -38,6 +38,18 @@ pub async fn build(
         None
     };
 
+    // Export process metrics (memory, CPU time, fds, threads):
+    if metrics.is_some() {
+        tokio::spawn(async {
+            let collector = metrics_process::Collector::default();
+            collector.describe();
+            loop {
+                collector.collect();
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await
+            }
+        });
+    }
+
     // Create node pool
     let node_conn_pool = NodePool::new(&config)?;
 


### PR DESCRIPTION
## Context

* Some SPOs already define their own Grafana dashboards.

* Also in the past we had problems with number of open FDs.

* This is cheap, and won’t hurt to have.

* The 2nd commit is just Nix noise to expose `libclang.dylib` to the builds on macOS’es.

## Result

```
❯ curl -fsSL http://0:3000/metrics | grep -E '^[a-z]' | sort

cardano_node_connections 1
cardano_node_connections_failed 0
cardano_node_connections_initiated 1
http_requests_total{method="GET",path="/metrics",status="200"} 31
process_cpu_seconds_total 0
process_max_fds 1024
process_open_fds 12
process_resident_memory_bytes 19488768
process_start_time_seconds 1742464582
process_threads 17
process_virtual_memory_bytes 1139335168
process_virtual_memory_max_bytes 0
tx_submit_failure 0
tx_submit_success 0
```
