### PR TITLE
Update pallas & refactor cbor validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,6 +422,7 @@ dependencies = [
  "pallas-network",
  "pallas-primitives",
  "pallas-traverse",
+ "pallas-validate",
  "pretty_assertions",
  "proptest",
  "reqwest",
@@ -2289,7 +2290,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "pallas"
 version = "0.32.0"
-source = "git+https://github.com/blockfrost/pallas.git?rev=478fd4ab1148c0d4f8591e202220ffb9ab243b5b#478fd4ab1148c0d4f8591e202220ffb9ab243b5b"
+source = "git+https://github.com/blockfrost/pallas.git?rev=f74c49e409570e7835a424bd20ad0cf9e86e0efb#f74c49e409570e7835a424bd20ad0cf9e86e0efb"
 dependencies = [
  "pallas-addresses",
  "pallas-codec",
@@ -2306,7 +2307,7 @@ dependencies = [
 [[package]]
 name = "pallas-addresses"
 version = "0.32.0"
-source = "git+https://github.com/blockfrost/pallas.git?rev=478fd4ab1148c0d4f8591e202220ffb9ab243b5b#478fd4ab1148c0d4f8591e202220ffb9ab243b5b"
+source = "git+https://github.com/blockfrost/pallas.git?rev=f74c49e409570e7835a424bd20ad0cf9e86e0efb#f74c49e409570e7835a424bd20ad0cf9e86e0efb"
 dependencies = [
  "base58",
  "bech32 0.9.1",
@@ -2321,7 +2322,7 @@ dependencies = [
 [[package]]
 name = "pallas-codec"
 version = "0.32.0"
-source = "git+https://github.com/blockfrost/pallas.git?rev=478fd4ab1148c0d4f8591e202220ffb9ab243b5b#478fd4ab1148c0d4f8591e202220ffb9ab243b5b"
+source = "git+https://github.com/blockfrost/pallas.git?rev=f74c49e409570e7835a424bd20ad0cf9e86e0efb#f74c49e409570e7835a424bd20ad0cf9e86e0efb"
 dependencies = [
  "hex",
  "minicbor",
@@ -2332,7 +2333,7 @@ dependencies = [
 [[package]]
 name = "pallas-configs"
 version = "0.32.0"
-source = "git+https://github.com/blockfrost/pallas.git?rev=478fd4ab1148c0d4f8591e202220ffb9ab243b5b#478fd4ab1148c0d4f8591e202220ffb9ab243b5b"
+source = "git+https://github.com/blockfrost/pallas.git?rev=f74c49e409570e7835a424bd20ad0cf9e86e0efb#f74c49e409570e7835a424bd20ad0cf9e86e0efb"
 dependencies = [
  "base64 0.22.1",
  "num-rational",
@@ -2347,7 +2348,7 @@ dependencies = [
 [[package]]
 name = "pallas-crypto"
 version = "0.32.0"
-source = "git+https://github.com/blockfrost/pallas.git?rev=478fd4ab1148c0d4f8591e202220ffb9ab243b5b#478fd4ab1148c0d4f8591e202220ffb9ab243b5b"
+source = "git+https://github.com/blockfrost/pallas.git?rev=f74c49e409570e7835a424bd20ad0cf9e86e0efb#f74c49e409570e7835a424bd20ad0cf9e86e0efb"
 dependencies = [
  "cryptoxide",
  "hex",
@@ -2360,7 +2361,7 @@ dependencies = [
 [[package]]
 name = "pallas-hardano"
 version = "0.32.0"
-source = "git+https://github.com/blockfrost/pallas.git?rev=478fd4ab1148c0d4f8591e202220ffb9ab243b5b#478fd4ab1148c0d4f8591e202220ffb9ab243b5b"
+source = "git+https://github.com/blockfrost/pallas.git?rev=f74c49e409570e7835a424bd20ad0cf9e86e0efb#f74c49e409570e7835a424bd20ad0cf9e86e0efb"
 dependencies = [
  "binary-layout",
  "hex",
@@ -2380,7 +2381,7 @@ dependencies = [
 [[package]]
 name = "pallas-network"
 version = "0.32.0"
-source = "git+https://github.com/blockfrost/pallas.git?rev=478fd4ab1148c0d4f8591e202220ffb9ab243b5b#478fd4ab1148c0d4f8591e202220ffb9ab243b5b"
+source = "git+https://github.com/blockfrost/pallas.git?rev=f74c49e409570e7835a424bd20ad0cf9e86e0efb#f74c49e409570e7835a424bd20ad0cf9e86e0efb"
 dependencies = [
  "byteorder 1.5.0",
  "hex",
@@ -2397,7 +2398,7 @@ dependencies = [
 [[package]]
 name = "pallas-primitives"
 version = "0.32.0"
-source = "git+https://github.com/blockfrost/pallas.git?rev=478fd4ab1148c0d4f8591e202220ffb9ab243b5b#478fd4ab1148c0d4f8591e202220ffb9ab243b5b"
+source = "git+https://github.com/blockfrost/pallas.git?rev=f74c49e409570e7835a424bd20ad0cf9e86e0efb#f74c49e409570e7835a424bd20ad0cf9e86e0efb"
 dependencies = [
  "hex",
  "pallas-codec",
@@ -2409,7 +2410,7 @@ dependencies = [
 [[package]]
 name = "pallas-traverse"
 version = "0.32.0"
-source = "git+https://github.com/blockfrost/pallas.git?rev=478fd4ab1148c0d4f8591e202220ffb9ab243b5b#478fd4ab1148c0d4f8591e202220ffb9ab243b5b"
+source = "git+https://github.com/blockfrost/pallas.git?rev=f74c49e409570e7835a424bd20ad0cf9e86e0efb#f74c49e409570e7835a424bd20ad0cf9e86e0efb"
 dependencies = [
  "hex",
  "itertools 0.13.0",
@@ -2425,7 +2426,7 @@ dependencies = [
 [[package]]
 name = "pallas-txbuilder"
 version = "0.32.0"
-source = "git+https://github.com/blockfrost/pallas.git?rev=478fd4ab1148c0d4f8591e202220ffb9ab243b5b#478fd4ab1148c0d4f8591e202220ffb9ab243b5b"
+source = "git+https://github.com/blockfrost/pallas.git?rev=f74c49e409570e7835a424bd20ad0cf9e86e0efb#f74c49e409570e7835a424bd20ad0cf9e86e0efb"
 dependencies = [
  "hex",
  "pallas-addresses",
@@ -2442,7 +2443,7 @@ dependencies = [
 [[package]]
 name = "pallas-utxorpc"
 version = "0.32.0"
-source = "git+https://github.com/blockfrost/pallas.git?rev=478fd4ab1148c0d4f8591e202220ffb9ab243b5b#478fd4ab1148c0d4f8591e202220ffb9ab243b5b"
+source = "git+https://github.com/blockfrost/pallas.git?rev=f74c49e409570e7835a424bd20ad0cf9e86e0efb#f74c49e409570e7835a424bd20ad0cf9e86e0efb"
 dependencies = [
  "pallas-codec",
  "pallas-crypto",
@@ -2456,7 +2457,7 @@ dependencies = [
 [[package]]
 name = "pallas-validate"
 version = "0.32.0"
-source = "git+https://github.com/blockfrost/pallas.git?rev=478fd4ab1148c0d4f8591e202220ffb9ab243b5b#478fd4ab1148c0d4f8591e202220ffb9ab243b5b"
+source = "git+https://github.com/blockfrost/pallas.git?rev=f74c49e409570e7835a424bd20ad0cf9e86e0efb#f74c49e409570e7835a424bd20ad0cf9e86e0efb"
 dependencies = [
  "chrono",
  "hex",
@@ -2474,7 +2475,7 @@ dependencies = [
 [[package]]
 name = "pallas-wallet"
 version = "0.32.0"
-source = "git+https://github.com/blockfrost/pallas.git?rev=478fd4ab1148c0d4f8591e202220ffb9ab243b5b#478fd4ab1148c0d4f8591e202220ffb9ab243b5b"
+source = "git+https://github.com/blockfrost/pallas.git?rev=f74c49e409570e7835a424bd20ad0cf9e86e0efb#f74c49e409570e7835a424bd20ad0cf9e86e0efb"
 dependencies = [
  "bech32 0.9.1",
  "bip39",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,14 +22,15 @@ thiserror = "2.0.11"
 sentry = "0.36.0"
 blake2 = "0.10.6"
 num_cpus = "1"
-pallas = { git = "https://github.com/blockfrost/pallas.git", rev = "478fd4ab1148c0d4f8591e202220ffb9ab243b5b" }
-pallas-network = { git = "https://github.com/blockfrost/pallas.git", rev = "478fd4ab1148c0d4f8591e202220ffb9ab243b5b" }
-pallas-crypto = { git = "https://github.com/blockfrost/pallas.git", rev = "478fd4ab1148c0d4f8591e202220ffb9ab243b5b" }
-pallas-traverse = { git = "https://github.com/blockfrost/pallas.git", rev = "478fd4ab1148c0d4f8591e202220ffb9ab243b5b" }
-pallas-codec = { git = "https://github.com/blockfrost/pallas.git", rev = "478fd4ab1148c0d4f8591e202220ffb9ab243b5b" }
-pallas-addresses = { git = "https://github.com/blockfrost/pallas.git", rev = "478fd4ab1148c0d4f8591e202220ffb9ab243b5b" }
-pallas-primitives = { git = "https://github.com/blockfrost/pallas.git", rev = "478fd4ab1148c0d4f8591e202220ffb9ab243b5b" }
-pallas-hardano = { git = "https://github.com/blockfrost/pallas.git", rev = "478fd4ab1148c0d4f8591e202220ffb9ab243b5b" }
+pallas = { git = "https://github.com/blockfrost/pallas.git", rev = "f74c49e409570e7835a424bd20ad0cf9e86e0efb" }
+pallas-network = { git = "https://github.com/blockfrost/pallas.git", rev = "f74c49e409570e7835a424bd20ad0cf9e86e0efb" }
+pallas-crypto = { git = "https://github.com/blockfrost/pallas.git", rev = "f74c49e409570e7835a424bd20ad0cf9e86e0efb" }
+pallas-traverse = { git = "https://github.com/blockfrost/pallas.git", rev = "f74c49e409570e7835a424bd20ad0cf9e86e0efb" }
+pallas-codec = { git = "https://github.com/blockfrost/pallas.git", rev = "f74c49e409570e7835a424bd20ad0cf9e86e0efb" }
+pallas-addresses = { git = "https://github.com/blockfrost/pallas.git", rev = "f74c49e409570e7835a424bd20ad0cf9e86e0efb" }
+pallas-primitives = { git = "https://github.com/blockfrost/pallas.git", rev = "f74c49e409570e7835a424bd20ad0cf9e86e0efb" }
+pallas-hardano = { git = "https://github.com/blockfrost/pallas.git", rev = "f74c49e409570e7835a424bd20ad0cf9e86e0efb" }
+pallas-validate = { git = "https://github.com/blockfrost/pallas.git", rev = "f74c49e409570e7835a424bd20ad0cf9e86e0efb" }
 reqwest = "0.12.12"
 hex = "0.4.3"
 cbor = "0.4.1"

--- a/src/cbor.rs
+++ b/src/cbor.rs
@@ -2,3 +2,4 @@ pub mod fallback_decoder;
 
 #[cfg(test)]
 pub mod tests;
+pub(crate) mod validation;

--- a/src/cbor/validation.rs
+++ b/src/cbor/validation.rs
@@ -1,0 +1,53 @@
+use pallas_hardano::display::haskell_error::as_cbor_decode_failure;
+use pallas_primitives::conway::MintedTx;
+use tracing::info;
+
+use crate::BlockfrostError;
+
+/// Checks if the given transaction is a valid CBOR-encoded transaction, by trying to decode it.
+/// This function is used to validate the transaction before submitting it to the node.
+/// If the transaction is invalid, returns the decoding error.
+/// If the transaction is valid, returns Ok(()).
+pub(crate) fn validate_tx_cbor(tx: &[u8]) -> Result<(), BlockfrostError> {
+    match pallas_codec::minicbor::decode::<MintedTx>(tx) {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            info!("Invalid TX CBOR: {:?}, CBOR: {}", e, hex::encode(tx));
+            Err(BlockfrostError::custom_400(as_cbor_decode_failure(
+                e.to_string(),
+                e.position().unwrap_or(0) as u64,
+            )))
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_tx_cbor() {
+        // Invalid CBOR bytes
+        let invalid_tx = vec![0xFF, 0xFF];
+        assert!(validate_tx_cbor(&invalid_tx).is_err());
+
+        let invalid_tx = hex::decode("aaaaaa").unwrap();
+        assert!(validate_tx_cbor(&invalid_tx).is_err());
+
+        let invalid_tx = hex::decode("88").unwrap();
+        assert!(validate_tx_cbor(&invalid_tx).is_err());
+
+        let empty_tx = vec![];
+        assert!(validate_tx_cbor(&empty_tx).is_err());
+
+        let invalid_tx = hex::decode("").unwrap();
+        assert!(validate_tx_cbor(&invalid_tx).is_err());
+
+        let invalid_tx = hex::decode("84a800848258204c16d304e6d531c59afd87a9199b7bb4175bc131b3d6746917901046b662963c00825820893c3f630c0b2db16d041c388aa0d58746ccbbc44133b2d7a3127a72c79722f1018258201e8f017df70bda0b4d129a66ab5297557920928c0261ed78fce16cf347430657028258208380ce7240ba59187f6450911f74a70cf3d2749228badb2e7cd10fb6499355f503018482581d61e15900a9a62a8fb01f936a25bf54af209c7ed1248c4e5abd05ec4e76821a0023ba63a1581ca0028f350aaabe0545fdcb56b039bfb08e4bb4d8c4d7c3c7d481c235a145484f534b5900a300581d71cba5c6770fe7b30ebc1fa32f01938c150513211360ded23ac76e36b301821a006336d5a3581c239075b83c03c2333eacd0b0beac6b8314f11ce3dc0c047012b0cad4a144706f6f6c01581c3547b4325e495d529619335603ababde10025dceafa9ed34b1fb6611a158208b284793d3bd4967244a2ddd68410d56d06d36ac8d201429b937096a2e8234bc1b7ffffffffffade6b581ca0028f350aaabe0545fdcb56b039bfb08e4bb4d8c4d7c3c7d481c235a145484f534b59195e99028201d818583ad8799fd8799f4040ffd8799f581ca0028f350aaabe0545fdcb56b039bfb08e4bb4d8c4d7c3c7d481c23545484f534b59ff1a006336d5195e99ff825839016d06090559d8ed2988aa5b2fff265d668cf552f4f62278c0128f816c0a48432e080280d0d9b15edb65563995f97ce236035afea568e660d1821a00118f32a1581c2f8b2d1f384485896f38406173fa11df2a4ce53b4b0886138b76597aa1476261746368657201825839016d06090559d8ed2988aa5b2fff265d668cf552f4f62278c0128f816c0a48432e080280d0d9b15edb65563995f97ce236035afea568e660d11a06d9f713021a000ab9e00b582027f17979d848d6472896266dd8bf39f7251ca23798713464bc407bf637286c230d81825820cf5de9189b958f8ad64c1f1837c2fa4711d073494598467a1c1a59589393eae20310825839016d06090559d8ed2988aa5b2fff265d668cf552f4f62278c0128f816c0a48432e080280d0d9b15edb65563995f97ce236035afea568e660d11a08666c75111a001016d01282825820bf93dc59c10c19c35210c2414779d7391ca19128cc7b13794ea85af5ff835f59008258201c37df764f8261edce8678b197767668a91d544b2b203fb5d0cf9acc10366e7600a200818258200eabfa083d7969681d2fc8e825a5f79e1c40f03aeac46ecd94bf5c5790db1bc05840a84fa0a9dd9547776502e4f54ab02e549277bc37332d3b9bbf4afa5afd8e33f042cdb92a0044ba9dbb8814f99960944ffa3c2c68fef9c738855ec1f67bf675010582840001d8799fd8799f011a006336d5195e991b7ffffffffffade6bd8799f1a000539e7ff01ffff821a000b46e41a0a7f3ca4840003d87d80821a002dccfe1a28868be8f5f6").unwrap();
+        assert!(validate_tx_cbor(&invalid_tx).is_err());
+
+        // A very basic transaction encoded as CBOR
+        let valid_tx = hex::decode("84a300d90102818258205176274bef11d575edd6aa72392aaf993a07f736e70239c1fb22d4b1426b22bc01018282583900ddf1eb9ce2a1561e8f156991486b97873fb6969190cbc99ddcb3816621dcb03574152623414ed354d2d8f50e310f3f2e7d167cb20e5754271a003d09008258390099a5cb0fa8f19aba38cacf8a243d632149129f882df3a8e67f6bd512bcb0cde66a545e9fbc7ca4492f39bca1f4f265cc1503b4f7d6ff205c1b000000024f127a7c021a0002a2ada100d90102818258208b83e59abc9d7a66a77be5e0825525546a595174f8b929f164fcf5052d7aab7b5840709c64556c946abf267edd90b8027343d065193ef816529d8fa7aa2243f1fd2ec27036a677974199e2264cb582d01925134b9a20997d5a734da298df957eb002f5f6").unwrap();
+        assert!(validate_tx_cbor(&valid_tx).is_ok());
+    }
+}

--- a/src/node/transactions.rs
+++ b/src/node/transactions.rs
@@ -1,12 +1,12 @@
 use super::connection::NodeClient;
 use crate::BlockfrostError;
+use crate::cbor::validation::validate_tx_cbor;
 use pallas_crypto::hash::Hasher;
-use pallas_hardano::display::haskell_error::{as_cbor_decode_failure, as_node_submit_error};
+use pallas_hardano::display::haskell_error::as_node_submit_error;
 use pallas_network::miniprotocols::{
     localstate,
     localtxsubmission::{EraTx, Response},
 };
-use pallas_primitives::conway::Tx;
 use tracing::{error, info};
 
 impl NodeClient {
@@ -17,7 +17,7 @@ impl NodeClient {
     /// * Swagger: <https://github.com/IntersectMBO/cardano-node/blob/6e969c6bcc0f07bd1a69f4d76b85d6fa9371a90b/cardano-submit-api/swagger.yaml#L52>
     /// * Haskell code: <https://github.com/IntersectMBO/cardano-node/blob/6e969c6bcc0f07bd1a69f4d76b85d6fa9371a90b/cardano-submit-api/src/Cardano/TxSubmit/Web.hs#L158>
     pub async fn submit_transaction(&mut self, tx: Vec<u8>) -> Result<String, BlockfrostError> {
-        Self::assert_valid_tx_cbor(&tx)?;
+        validate_tx_cbor(&tx)?;
 
         let current_era = self
             .with_statequery(|generic_client: &mut localstate::GenericClient| {
@@ -72,52 +72,28 @@ impl NodeClient {
             },
         }
     }
-
-    fn assert_valid_tx_cbor(tx: &[u8]) -> Result<(), BlockfrostError> {
-        match pallas_codec::minicbor::decode::<Tx>(tx) {
-            Ok(_) => Ok(()),
-            Err(e) => {
-                info!(
-                    "Invalid TX CBOR submitted: {:?}, CBOR: {}",
-                    e,
-                    hex::encode(tx)
-                );
-                Err(BlockfrostError::custom_400(as_cbor_decode_failure(
-                    e.to_string(),
-                    e.position().unwrap_or(0) as u64,
-                )))
-            },
-        }
-    }
 }
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_assert_valid_tx_cbor() {
-        // Invalid CBOR bytes
+    /// This test makes sure in case of invalid CBOR transaction, submit_transaction returns an error without even going to the node.
+    #[tokio::test]
+    async fn test_submit_transaction_invalid() {
+        let mut client = NodeClient {
+            client: None,
+            connection_id: 0,
+            unrecoverable_error_happened: false,
+        };
+
+        // Test invalid CBOR transaction
         let invalid_tx = vec![0xFF, 0xFF];
-        assert!(NodeClient::assert_valid_tx_cbor(&invalid_tx).is_err());
+        let result = client.submit_transaction(invalid_tx).await;
+        assert!(result.is_err());
 
-        let invalid_tx = "aaaaaa".as_bytes().to_vec();
-        assert!(NodeClient::assert_valid_tx_cbor(&invalid_tx).is_err());
-
-        let invalid_tx = "8".as_bytes().to_vec();
-        assert!(NodeClient::assert_valid_tx_cbor(&invalid_tx).is_err());
-
-        let invalid_tx = "821".as_bytes().to_vec();
-        assert!(NodeClient::assert_valid_tx_cbor(&invalid_tx).is_err());
-        // Empty bytes
-        let empty_tx = vec![];
-        assert!(NodeClient::assert_valid_tx_cbor(&empty_tx).is_err());
-
-        let invalid_tx = "".as_bytes().to_vec();
-        assert!(NodeClient::assert_valid_tx_cbor(&invalid_tx).is_err());
-
-        // Sample valid CBOR bytes representing a minimal TransactionBody
-        // This is a very basic transaction body encoded as CBOR
-        let valid_tx = hex::decode("84a300d90102818258205176274bef11d575edd6aa72392aaf993a07f736e70239c1fb22d4b1426b22bc01018282583900ddf1eb9ce2a1561e8f156991486b97873fb6969190cbc99ddcb3816621dcb03574152623414ed354d2d8f50e310f3f2e7d167cb20e5754271a003d09008258390099a5cb0fa8f19aba38cacf8a243d632149129f882df3a8e67f6bd512bcb0cde66a545e9fbc7ca4492f39bca1f4f265cc1503b4f7d6ff205c1b000000024f127a7c021a0002a2ada100d90102818258208b83e59abc9d7a66a77be5e0825525546a595174f8b929f164fcf5052d7aab7b5840709c64556c946abf267edd90b8027343d065193ef816529d8fa7aa2243f1fd2ec27036a677974199e2264cb582d01925134b9a20997d5a734da298df957eb002f5f6").unwrap();
-        assert!(NodeClient::assert_valid_tx_cbor(&valid_tx).is_ok());
+        // Test invalid CBOR transaction 2
+        let invalid_tx = "84a800848258204c16d304e6d531c59afd87a9199b7bb4175bc131b3d6746917901046b662963c00825820893c3f630c0b2db16d041c388aa0d58746ccbbc44133b2d7a3127a72c79722f1018258200998adb591c872a241776e39fe855e04b2d7c361008e94c582f59b6b6ccc452c028258208380ce7240ba59187f6450911f74a70cf3d2749228badb2e7cd10fb6499355f503018482581d61e15900a9a62a8fb01f936a25bf54af209c7ed1248c4e5abd05ec4e76821a0023ba63a1581ca0028f350aaabe0545fdcb56b039bfb08e4bb4d8c4d7c3c7d481c235a145484f534b5900a300581d71cba5c6770fe7b30ebc1fa32f01938c150513211360ded23ac76e36b301821a006336d5a3581c239075b83c03c2333eacd0b0beac6b8314f11ce3dc0c047012b0cad4a144706f6f6c01581c3547b4325e495d529619335603ababde10025dceafa9ed34b1fb6611a158208b284793d3bd4967244a2ddd68410d56d06d36ac8d201429b937096a2e8234bc1b7ffffffffffade6b581ca0028f350aaabe0545fdcb56b039bfb08e4bb4d8c4d7c3c7d481c235a145484f534b59195e99028201d818583ad8799fd8799f4040ffd8799f581ca0028f350aaabe0545fdcb56b039bfb08e4bb4d8c4d7c3c7d481c23545484f534b59ff1a006336d5195e99ff825839016d06090559d8ed2988aa5b2fff265d668cf552f4f62278c0128f816c0a48432e080280d0d9b15edb65563995f97ce236035afea568e660d1821a00118f32a1581c2f8b2d1f384485896f38406173fa11df2a4ce53b4b0886138b76597aa1476261746368657201825839016d06090559d8ed2988aa5b2fff265d668cf552f4f62278c0128f816c0a48432e080280d0d9b15edb65563995f97ce236035afea568e660d11a06d9f713021a000ab9e00b582027f17979d848d6472896266dd8bf39f7251ca23798713464bc407bf637286c230d81825820cf5de9189b958f8ad64c1f1837c2fa4711d073494598467a1c1a59589393eae20310825839016d06090559d8ed2988aa5b2fff265d668cf552f4f62278c0128f816c0a48432e080280d0d9b15edb65563995f97ce236035afea568e660d11a08666c75111a001016d01282825820bf93dc59c10c19c35210c2414779d7391ca19128cc7b13794ea85af5ff835f59008258201c37df764f8261edce8678b197767668a91d544b2b203fb5d0cf9acc10366e7600a200818258200eabfa083d7969681d2fc8e825a5f79e1c40f03aeac46ecd94bf5c5790db1bc058409a029ddd3cdde65598bb712c640ea63eeebfee526ce49bd0983b4d1fdca858481ddf931bf0354552cc0a7d3365e2f03fdb457c0466cea8b371b645f9b6d0c2010582840001d8799fd8799f011a006336d5195e991b7ffffffffffade6bd8799f1a000539e7ff01ffff821a000b46e41a0a7f3ca4840003d87d80821a002dccfe1a28868be8f5f6".as_bytes().to_vec();
+        let result = client.submit_transaction(invalid_tx).await;
+        assert!(result.is_err());
     }
 }

--- a/tests/endpoints_test.rs
+++ b/tests/endpoints_test.rs
@@ -152,6 +152,36 @@ mod tests {
         asserts::assert_submit_error_responses(&bf_body_bytes, &local_body_bytes);
     }
 
+    // validation of the fix: https://github.com/blockfrost/blockfrost-platform/issues/238#issuecomment-2747354365
+    #[tokio::test]
+    async fn test_route_submit_agent_dequeu() {
+        initialize_logging();
+        let (app, _, _, _) = build_app().await.expect("Failed to build the application");
+
+        let tx = "84a800848258204c16d304e6d531c59afd87a9199b7bb4175bc131b3d6746917901046b662963c00825820893c3f630c0b2db16d041c388aa0d58746ccbbc44133b2d7a3127a72c79722f1018258200998adb591c872a241776e39fe855e04b2d7c361008e94c582f59b6b6ccc452c028258208380ce7240ba59187f6450911f74a70cf3d2749228badb2e7cd10fb6499355f503018482581d61e15900a9a62a8fb01f936a25bf54af209c7ed1248c4e5abd05ec4e76821a0023ba63a1581ca0028f350aaabe0545fdcb56b039bfb08e4bb4d8c4d7c3c7d481c235a145484f534b5900a300581d71cba5c6770fe7b30ebc1fa32f01938c150513211360ded23ac76e36b301821a006336d5a3581c239075b83c03c2333eacd0b0beac6b8314f11ce3dc0c047012b0cad4a144706f6f6c01581c3547b4325e495d529619335603ababde10025dceafa9ed34b1fb6611a158208b284793d3bd4967244a2ddd68410d56d06d36ac8d201429b937096a2e8234bc1b7ffffffffffade6b581ca0028f350aaabe0545fdcb56b039bfb08e4bb4d8c4d7c3c7d481c235a145484f534b59195e99028201d818583ad8799fd8799f4040ffd8799f581ca0028f350aaabe0545fdcb56b039bfb08e4bb4d8c4d7c3c7d481c23545484f534b59ff1a006336d5195e99ff825839016d06090559d8ed2988aa5b2fff265d668cf552f4f62278c0128f816c0a48432e080280d0d9b15edb65563995f97ce236035afea568e660d1821a00118f32a1581c2f8b2d1f384485896f38406173fa11df2a4ce53b4b0886138b76597aa1476261746368657201825839016d06090559d8ed2988aa5b2fff265d668cf552f4f62278c0128f816c0a48432e080280d0d9b15edb65563995f97ce236035afea568e660d11a06d9f713021a000ab9e00b582027f17979d848d6472896266dd8bf39f7251ca23798713464bc407bf637286c230d81825820cf5de9189b958f8ad64c1f1837c2fa4711d073494598467a1c1a59589393eae20310825839016d06090559d8ed2988aa5b2fff265d668cf552f4f62278c0128f816c0a48432e080280d0d9b15edb65563995f97ce236035afea568e660d11a08666c75111a001016d01282825820bf93dc59c10c19c35210c2414779d7391ca19128cc7b13794ea85af5ff835f59008258201c37df764f8261edce8678b197767668a91d544b2b203fb5d0cf9acc10366e7600a200818258200eabfa083d7969681d2fc8e825a5f79e1c40f03aeac46ecd94bf5c5790db1bc058409a029ddd3cdde65598bb712c640ea63eeebfee526ce49bd0983b4d1fdca858481ddf931bf0354552cc0a7d3365e2f03fdb457c0466cea8b371b645f9b6d0c2010582840001d8799fd8799f011a006336d5195e991b7ffffffffffade6bd8799f1a000539e7ff01ffff821a000b46e41a0a7f3ca4840003d87d80821a002dccfe1a28868be8f5f6";
+
+        // Local (Platform)
+        let local_request = Request::builder()
+            .method(Method::POST)
+            .uri("/tx/submit")
+            .header("Content-Type", "application/cbor")
+            .body(Body::from(tx))
+            .unwrap();
+
+        let local_response = app
+            .oneshot(local_request)
+            .await
+            .expect("Request to /tx/submit failed");
+
+        let local_body_bytes = to_bytes(local_response.into_body(), usize::MAX)
+            .await
+            .expect("Failed to read response body");
+
+        let local_body_str = String::from_utf8(local_body_bytes.to_vec())
+            .expect("Failed to convert bytes to string");
+        assert!(local_body_str.contains("MultiAsset cannot contain zeros"));
+    }
+
     // Test: build `/tx/submit` success - tx is accepted by the node
     #[tokio::test]
     async fn test_route_submit_success() {


### PR DESCRIPTION
Related to:
* #238

I wrote a [workaround](https://github.com/txpipe/pallas/commit/f74c49e409570e7835a424bd20ad0cf9e86e0efb) in pallas.

I did a workaround since a "proper fix" is going to touch lots of places. No need to put lots of effort into it, knowing that the pallas team is getting rid of the related PseudoTransactionOutput data structure.

I am also implementing pallas-validate validations. It mimics the ledger validations. But we won't use it to replace node generated validation errors. Instead, I am planning to use it to generate more errors in case of more dequeue failures.