### PR TITLE
chore: make it easy to plug other error sources to `GET /`

### DIFF
--- a/src/health_monitor.rs
+++ b/src/health_monitor.rs
@@ -1,6 +1,6 @@
 use crate::{BlockfrostError, NodePool, node::sync_progress::NodeInfo};
 use std::sync::Arc;
-use tokio::sync::{Notify, RwLock};
+use tokio::sync::{Mutex, Notify};
 use tokio::time::{self, Duration};
 
 #[derive(Clone)]
@@ -10,88 +10,178 @@ pub struct HealthStatus {
     pub node_info: Option<NodeInfo>,
 }
 
+/// An alias for Clippy:
+type ErrorSource = Arc<Mutex<Vec<BlockfrostError>>>;
+
 #[derive(Clone)]
 pub struct HealthMonitor {
-    inner: Arc<RwLock<HealthStatus>>,
+    sources: Arc<Mutex<Vec<ErrorSource>>>,
+    node_info: Arc<Mutex<Option<NodeInfo>>>,
 }
 
 impl HealthMonitor {
+    /// This is what `GET /` calls.
     pub async fn current_status(&self) -> HealthStatus {
-        self.inner.read().await.clone()
+        let errors = Self::collect_errors(&self.sources.lock().await).await;
+        let node_info = self.node_info.lock().await.clone();
+        let healthy = errors.is_empty();
+        HealthStatus {
+            errors,
+            node_info,
+            healthy,
+        }
+    }
+
+    /// Collect errors across multiple sources.
+    async fn collect_errors(sources: &[Arc<Mutex<Vec<BlockfrostError>>>]) -> Vec<BlockfrostError> {
+        let mut errors = vec![];
+        for src in sources {
+            let errs = src.lock().await;
+            for error in errs.iter() {
+                errors.push(error.clone());
+            }
+        }
+        errors
+    }
+
+    /// Adds this shared vector as one of the sources of errors reported under
+    /// `GET /`. You can then modify the vectors (including emptying them) to
+    /// modify the final reported list. A way to compose more persistent errors
+    /// from different parts of the app.
+    pub async fn register_error_source(&self, src: Arc<Mutex<Vec<BlockfrostError>>>) {
+        self.sources.lock().await.push(src)
+    }
+
+    /// Starts various health monitors in the background.
+    pub async fn spawn(node: NodePool) -> Self {
+        let node_mon = node_monitor::NodeMonitor::new();
+        let mut chain_mon = chain_staleness_monitor::ChainStalenessMonitor::new();
+
+        let self_ = Self {
+            sources: Arc::new(Mutex::new(vec![])),
+            node_info: node_mon.node_info(),
+        };
+
+        self_.register_error_source(node_mon.errors()).await;
+        self_.register_error_source(chain_mon.errors()).await;
+
+        let notify_state_update = Arc::new(Notify::new());
+        let notify_state_update_ = notify_state_update.clone();
+
+        tokio::spawn(async move {
+            loop {
+                node_mon.update(&node).await;
+                chain_mon
+                    .update(&*(node_mon.node_info().lock().await))
+                    .await;
+                notify_state_update_.notify_one();
+
+                // Set delay based on health status
+                let node_healthy = Self::collect_errors(&[node_mon.errors(), chain_mon.errors()])
+                    .await
+                    .is_empty();
+                let delay = Duration::from_secs(if node_healthy { 10 } else { 2 });
+
+                time::sleep(delay).await;
+            }
+        });
+
+        notify_state_update.notified().await;
+        self_
     }
 }
 
-const CHAIN_STALE_IF_OLDER_THAN: std::time::Duration = std::time::Duration::from_secs(5 * 60);
+mod node_monitor {
+    use crate::{BlockfrostError, NodePool, node::sync_progress::NodeInfo};
+    use std::sync::Arc;
+    use tokio::sync::Mutex;
 
-pub async fn spawn(node: NodePool) -> HealthMonitor {
-    // This initial state is never seen:
-    let state_ = Arc::new(RwLock::new(HealthStatus {
-        healthy: false,
-        errors: vec![],
-        node_info: None,
-    }));
-    let state = state_.clone();
+    pub struct NodeMonitor {
+        errors: Arc<Mutex<Vec<BlockfrostError>>>,
+        node_info: Arc<Mutex<Option<NodeInfo>>>,
+    }
 
-    let state_update_ = Arc::new(Notify::new());
-    let state_update = state_update_.clone();
+    impl NodeMonitor {
+        pub fn new() -> Self {
+            Self {
+                errors: Arc::new(Mutex::new(vec![])),
+                node_info: Arc::new(Mutex::new(None)),
+            }
+        }
 
-    tokio::spawn(async move {
-        let mut last_chain_advancement = std::time::Instant::now();
-        let mut last_chain_block =
-            "0000000000000000000000000000000000000000000000000000000000000000".to_string();
-
-        loop {
+        pub async fn update(&self, node: &NodePool) {
             let node_info: Result<NodeInfo, BlockfrostError> = async {
                 let mut node = node.get().await?;
                 node.sync_progress().await
             }
             .await;
 
-            if let Ok(node_info) = node_info.as_ref() {
-                if last_chain_block != node_info.block {
-                    last_chain_block = node_info.block.clone();
-                    last_chain_advancement = std::time::Instant::now();
+            let (node_info, errors) = match node_info {
+                Ok(a) => (Some(a), vec![]),
+                Err(err) => (None, vec![err]),
+            };
+
+            *(self.errors.lock().await) = errors;
+            *(self.node_info.lock().await) = node_info;
+        }
+
+        pub fn errors(&self) -> Arc<Mutex<Vec<BlockfrostError>>> {
+            self.errors.clone()
+        }
+
+        pub fn node_info(&self) -> Arc<Mutex<Option<NodeInfo>>> {
+            self.node_info.clone()
+        }
+    }
+}
+
+mod chain_staleness_monitor {
+    use crate::{BlockfrostError, node::sync_progress::NodeInfo};
+    use std::sync::Arc;
+    use tokio::sync::Mutex;
+
+    const CHAIN_STALE_IF_OLDER_THAN: std::time::Duration = std::time::Duration::from_secs(5 * 60);
+
+    pub struct ChainStalenessMonitor {
+        last_chain_advancement: std::time::Instant,
+        last_chain_block: String,
+        errors: Arc<Mutex<Vec<BlockfrostError>>>,
+    }
+
+    impl ChainStalenessMonitor {
+        pub fn new() -> Self {
+            Self {
+                last_chain_advancement: std::time::Instant::now(),
+                last_chain_block:
+                    "0000000000000000000000000000000000000000000000000000000000000000".to_string(),
+                errors: Arc::new(Mutex::new(vec![])),
+            }
+        }
+
+        pub async fn update(&mut self, node_info: &Option<NodeInfo>) {
+            if let Some(node_info) = node_info {
+                if self.last_chain_block != node_info.block {
+                    self.last_chain_block = node_info.block.clone();
+                    self.last_chain_advancement = std::time::Instant::now();
                 }
             }
 
-            let chain_too_stale = {
-                let elapsed = last_chain_advancement.elapsed();
-                if elapsed > CHAIN_STALE_IF_OLDER_THAN {
-                    let err = format!(
-                        "Chain stuck at {}, has not seen updates in {:?}.",
-                        last_chain_block, elapsed
-                    );
-                    tracing::error!("{}", err);
-                    Some(BlockfrostError::internal_server_error(err))
-                } else {
-                    None
-                }
+            let elapsed = self.last_chain_advancement.elapsed();
+
+            *(self.errors.lock().await) = if elapsed > CHAIN_STALE_IF_OLDER_THAN {
+                let err = format!(
+                    "Chain stuck at {}, has not seen updates in {:?}.",
+                    self.last_chain_block, elapsed
+                );
+                tracing::error!("{}", err);
+                vec![BlockfrostError::internal_server_error(err)]
+            } else {
+                vec![]
             };
-
-            let errors: Vec<BlockfrostError> = node_info
-                .clone()
-                .err()
-                .into_iter()
-                .chain(chain_too_stale.into_iter())
-                .collect();
-            let healthy = errors.is_empty();
-            let node_info = node_info.ok();
-
-            *(state.write().await) = HealthStatus {
-                errors,
-                healthy,
-                node_info,
-            };
-
-            state_update.notify_one();
-
-            // Set delay based on health status
-            let delay = Duration::from_secs(if healthy { 10 } else { 2 });
-            time::sleep(delay).await;
         }
-    });
 
-    state_update_.notified().await;
-
-    HealthMonitor { inner: state_ }
+        pub fn errors(&self) -> Arc<Mutex<Vec<BlockfrostError>>> {
+            self.errors.clone()
+        }
+    }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -53,7 +53,7 @@ pub async fn build(
     // Create node pool
     let node_conn_pool = NodePool::new(&config)?;
 
-    let health_monitor = health_monitor::spawn(node_conn_pool.clone()).await;
+    let health_monitor = health_monitor::HealthMonitor::spawn(node_conn_pool.clone()).await;
 
     // Build a prefix
     let api_prefix = if config.icebreakers_config.is_some() {


### PR DESCRIPTION
Related to:
* #178

## Context

I need to be able to plug load balancer errors into our health response, now it’s easy, just call `.register_error_source()` from anywhere.