### PR TITLE
feat: use a WebSocket load balancer to allow connections from behind NAT(s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- Load balancing over a WebSocket (eliminating the need for public IP in the future)
+
 - Expose a `health_errors_total` gauge in metrics
 
 ## [0.0.2] - 2025-03-20

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -150,6 +150,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efea76243612a2436fb4074ba0cf3ba9ea29efdeb72645d8fc63f116462be1de"
 dependencies = [
  "axum-core",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -169,8 +170,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -394,6 +397,7 @@ version = "0.0.2"
 dependencies = [
  "anyhow",
  "axum",
+ "base64 0.22.1",
  "bip39",
  "blake2",
  "blockfrost",
@@ -406,7 +410,10 @@ dependencies = [
  "deadpool",
  "dirs",
  "dotenvy",
+ "futures",
+ "futures-util",
  "hex",
+ "hyper",
  "inquire",
  "jemalloc",
  "metrics",
@@ -434,6 +441,7 @@ dependencies = [
  "tar",
  "thiserror 2.0.11",
  "tokio",
+ "tokio-tungstenite",
  "toml 0.8.19",
  "tower",
  "tower-http",
@@ -441,6 +449,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing-test",
+ "tungstenite",
  "twelf",
  "uuid",
  "zip",
@@ -498,7 +507,7 @@ dependencies = [
  "cryptoxide",
  "digest 0.9.0",
  "ed25519-bip32",
- "getrandom",
+ "getrandom 0.2.15",
  "hashlink",
  "hex",
  "itertools 0.10.5",
@@ -509,7 +518,7 @@ dependencies = [
  "num-derive",
  "num-integer",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "rand_os",
  "schemars",
  "serde",
@@ -855,6 +864,12 @@ dependencies = [
  "quote",
  "syn 2.0.96",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
 
 [[package]]
 name = "deadpool"
@@ -1238,8 +1253,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -1935,7 +1962,7 @@ dependencies = [
  "hashbrown 0.15.2",
  "metrics",
  "quanta",
- "rand",
+ "rand 0.8.5",
  "rand_xoshiro",
  "sketches-ddsketch",
 ]
@@ -2000,7 +2027,7 @@ checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
 
@@ -2011,7 +2038,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -2371,7 +2398,7 @@ dependencies = [
  "itertools 0.13.0",
  "pallas-codec",
  "pallas-crypto",
- "rand",
+ "rand 0.8.5",
  "socket2",
  "thiserror 1.0.69",
  "tokio",
@@ -2465,7 +2492,7 @@ dependencies = [
  "cryptoxide",
  "ed25519-bip32",
  "pallas-crypto",
- "rand",
+ "rand 0.8.5",
  "thiserror 1.0.69",
 ]
 
@@ -2630,7 +2657,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -2704,8 +2731,8 @@ dependencies = [
  "bitflags 2.8.0",
  "lazy_static",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax 0.8.5",
  "rusty-fork",
@@ -2781,7 +2808,7 @@ dependencies = [
  "libc",
  "once_cell",
  "raw-cpuid",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
 ]
@@ -2802,14 +2829,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a2af567ac9e1e7d2d11097ca14a1e463a5c06a2ee84c23c009b489b00afc1fc"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+ "zerocopy 0.8.23",
 ]
 
 [[package]]
@@ -2820,6 +2864,16 @@ checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2843,7 +2897,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.2",
 ]
 
 [[package]]
@@ -2932,7 +2995,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -3041,7 +3104,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -3303,7 +3366,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "653942e6141f16651273159f4b8b1eaeedf37a7554c00cd798953e64b8a9bf72"
 dependencies = [
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "sentry-types",
  "serde",
  "serde_json",
@@ -3350,7 +3413,7 @@ checksum = "2d4203359e60724aa05cf2385aaf5d4f147e837185d7dd2b9ccf1ee77f4420c8"
 dependencies = [
  "debugid",
  "hex",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -3714,7 +3777,7 @@ checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
 dependencies = [
  "cfg-if",
  "fastrand",
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -3883,6 +3946,18 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
 ]
 
 [[package]]
@@ -4094,6 +4169,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.0",
+ "sha1",
+ "thiserror 2.0.11",
+ "utf-8",
+]
+
+[[package]]
 name = "twelf"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4196,6 +4288,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "utf16_iter"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4235,7 +4333,7 @@ version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "serde",
 ]
 
@@ -4280,6 +4378,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -4684,6 +4791,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.8.0",
+]
+
+[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4743,7 +4859,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
+dependencies = [
+ "zerocopy-derive 0.8.23",
 ]
 
 [[package]]
@@ -4751,6 +4876,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,21 +6,27 @@ edition = "2021"
 build = "build.rs"
 
 [dependencies]
-axum = "0.8.1"
+axum = { version = "0.8.2", features = ["ws"] }
 tokio = { version = "1.43.0", features = ["rt", "rt-multi-thread", "signal"] }
+futures = "0.3"
+futures-util = "0.3"
 crossbeam = "0.8"
+tungstenite = "0.26"
+tokio-tungstenite = "0.26"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter", "fmt"] }
 serde = { version = "1.0.218", features = ["derive"] }
 tower-http = { version = "0.6.1", features = ["normalize-path"] }
 tower-layer = "0.3.2"
 tower = "0.5.1"
+hyper = "1.5.2"
 serde_json = "1.0.135"
 clap = { version = "4.5.26", features = ["derive"] }
 toml = "0.8.19"
 thiserror = "2.0.11"
 sentry = "0.36.0"
 blake2 = "0.10.6"
+base64 = "0.22.1"
 num_cpus = "1"
 pallas = { git = "https://github.com/blockfrost/pallas.git", rev = "f74c49e409570e7835a424bd20ad0cf9e86e0efb" }
 pallas-network = { git = "https://github.com/blockfrost/pallas.git", rev = "f74c49e409570e7835a424bd20ad0cf9e86e0efb" }

--- a/docs/src/content/icebreakers.mdx
+++ b/docs/src/content/icebreakers.mdx
@@ -10,7 +10,8 @@ Blockfrost customers seamlessly access this blockchain-stored data through the I
 
 ## Diagram
 
-The following diagram generally represents the first iteration of the Blockfrost Icebreakers network:
+The following diagram generally represents the first iteration of the Blockfrost Icebreakers network.
+For more information, see the [Technical details](#technical-details) section below.
 
 ![Icebreakers network diagram](/icebreakers_network_diagram.png)
 
@@ -18,3 +19,166 @@ The following diagram generally represents the first iteration of the Blockfrost
 
 We still have some places left.
 Come talk to us on [Discord](https://discord.com/invite/inputoutput) in the `#ask-blockfrost` channel.
+
+## Technical details
+
+The following sequence diagram provides a high-level overview of the communication:
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant LoadBalancer as Load balancers<br>(currently Icebreakers API)
+    participant Relay as Blockfrost platform<br>(behind NAT(s))
+    participant IcebreakersAPI as Icebreakers API
+
+    rect rgb(240, 240, 240)
+    Note over IcebreakersAPI,Relay: 1. Register
+    Relay->>IcebreakersAPI: POST /register
+    IcebreakersAPI-->>Relay: {"load_balancers": [{"uri": …, "access_token": …}, …]}
+    end
+
+    rect rgb(240, 240, 240)
+    Note over LoadBalancer,Relay: 2. Connect over WebSocket
+    Relay->>LoadBalancer: WebSocket handshake w/ Authorization: Bearer
+    LoadBalancer-->>Relay: 101 Switching Protocols
+    end
+
+    rect rgb(240, 240, 240)
+    Note over Relay,LoadBalancer: 3. Ping–Pong to monitor connection liveness & RTT
+    LoadBalancer->>Relay: Ping
+    Relay-->>LoadBalancer: Pong
+    Relay->>LoadBalancer: Ping
+    LoadBalancer-->>Relay: Pong
+    end
+
+    rect rgb(240, 240, 240)
+    Note over Client,Relay: 4. Forwarding requests
+    Client->>LoadBalancer: GET /{api_prefix}/{path}
+    LoadBalancer->>Relay: JSON-encoded request over WebSocket
+    Relay-->>LoadBalancer: JSON-encoded response over WebSocket
+    LoadBalancer-->>Client: HTTP 200 (4××) response
+    end
+```
+
+### 1. Register
+
+In [non-solitary mode](/options), when registering with the `blockfrost-icebreakers-api`, the `blockfrost-platform` gets an additional field in the successful response, with a list of load balancers to connect to:
+
+```json
+{
+  "route": "b0be51e5-e5fe-4e42-98a9-2246173bea19",
+  "load_balancers": [
+    {
+      "uri": "wss://icebreakers-api.blockfrost.io/ws",
+      "access_token": "QNo3SYA0iPY+LfEhb2Gi5NaUOXqLw4b7ZQyg9DL4hFs="
+    }
+  ]
+}
+```
+
+### 2. Connect over WebSocket
+
+`blockfrost-platform` connects to the WebSocket endpoint, and sets `Authorization: Bearer <access_token>`.
+
+Currently, this new WebSocket endpoint is served by the same IceBreakers API during initial testing. In the future, there will be multiple load balancers for high-availability.
+
+### 3. Ping–Pong to monitor connection liveness, and the round-trip time
+
+1. Both sides exchange `Ping` and `Pong` messages continuously, which allows us to detect the other side going offline quite quickly, even with silently dropped packets. And also to measure the pure network round-trip time, without the overhead of any advanced calculations.
+
+2. The load balancer code exposes a `GET /stats` endpoint, where you can see all currently connected IceBreakers:
+
+   ```
+   ❯ curl -fsSL http://icebreakers-api.blockfrost.io/stats | jq .
+   ```
+
+   ```json
+   {
+     "IcebreakerX": {
+       "api_prefix": "b0be51e5-e5fe-4e42-98a9-2246173bea19",
+       "network_rtt_seconds": 0.000387182,
+       "connected_since": "2025-03-28T19:09:46.399124184Z",
+       "requests_sent": 0,
+       "responses_received": 0,
+       "requests_in_progress": 0
+     }
+   }
+   ```
+
+### 4. Forwarding requests
+
+1. The most important load balancer endpoints are `GET /{api_prefix}/{path}`, and `POST /{api_prefix}/{path}`:
+
+   1. Using the example above, once you issue: `curl -fsSL https://icebreakers-api.blockfrost.io/b0be51e5-e5fe-4e42-98a9-2246173bea19/`,
+   2. this request will be translated into a JSON message, and sent over the WebSocket connection with IcebreakerX (identified by its `api_prefix`):
+
+      ```json
+      {
+        "id": "04810b96-87cd-4af0-8c1b-7b5e00806769",
+        "method": "GET",
+        "path": "/",
+        "header": [
+          {
+            "name": "host",
+            "value": "0.0.0.0:3001"
+          },
+          {
+            "name": "user-agent",
+            "value": "curl/8.11.1"
+          },
+          {
+            "name": "accept",
+            "value": "*/*"
+          }
+        ],
+        "body_base64": ""
+      }
+      ```
+
+   3. Then this particular `blockfrost-platform` will resolve the request against its local HTTP server – all cheap, and in memory, without opening any new TCP connections to itself.
+   4. The response is encoded back into a JSON response message, and sent over the WebSocket to the load balancer:
+
+      ```json
+      {
+        "id": "04810b96-87cd-4af0-8c1b-7b5e00806769",
+        "code": 200,
+        "header": [
+          {
+            "name": "content-type",
+            "value": "application/json"
+          },
+          {
+            "name": "content-length",
+            "value": "241"
+          }
+        ],
+        "body_base64": "eyJuYW1lIjoiYmxvY2tmcm9zdC1wbGF0Zm9ybSIsInZlcnNpb24iOiIwLjAuMiIsInJldmlzaW9uIjoiZGlydHkiLCJoZWFsdGh5Ijp0cnVlLCJub2RlX2luZm8iOnsiYmxvY2siOiIyNjkzZTk1M2M4NmU0NzZlNGZhMmFhYWY2MDZjZWRjOThhZmU1ZjEwZTFhZDViYTk3NmNmZDkxNzI4NGI4MGJiIiwiZXBvY2giOjg4NSwiZXJhIjo2LCJzbG90Ijo3NjU0MjI5Niwic3luY19wcm9ncmVzcyI6OTkuOTV9LCJlcnJvcnMiOltdfQ=="
+      }
+      ```
+
+   5. Which in turn converts it to a HTTP response, and sends it to the end user.
+
+   Example:
+
+   ```
+   ❯ curl -fsSL https://icebreakers-api.blockfrost.io/b0be51e5-e5fe-4e42-98a9-2246173bea19/ | jq .
+   ```
+
+   ```json
+   {
+     "name": "blockfrost-platform",
+     "version": "0.0.2",
+     "revision": "c21d2d93a2da14174ed4a8ba247c75c8971ce507",
+     "healthy": true,
+     "node_info": {
+       "block": "6d87f87a0642fd4a59bb8af89400e8c7a777e290d2c2e02ceb93059ac7b4aaba",
+       "epoch": 885,
+       "era": 6,
+       "slot": 76533840,
+       "sync_progress": 100.0
+     },
+     "errors": []
+   }
+   ```
+
+2. The `blockfrost-platform` API remains as-is on port 3000. After the WebSocket testing period it will no longer need to be open to the public, or have a UUID `api_prefix`.

--- a/docs/src/content/options.md
+++ b/docs/src/content/options.md
@@ -2,41 +2,41 @@
 
 The Blockfrost platform accepts the following advanced options:
 
-`--server-address <SERVER_ADDRESS>`
+`--server-address <SERVER_ADDRESS>`\
 Default: 0.0.0.0
 
-`--server-port <SERVER_PORT>`
+`--server-port <SERVER_PORT>`\
 Default: 3000
 
-`--network <NETWORK> (required)`
+`--network <NETWORK>` (required)\
 Possible values: mainnet, preprod, preview
 
-`--log-level <LOG_LEVEL>`
-Default: info
+`--log-level <LOG_LEVEL>`\
+Default: info\
 Possible values: debug, info, warn, error, trace
 
-`--node-socket-path <NODE_SOCKET_PATH> (required)`
+`--node-socket-path <NODE_SOCKET_PATH>` (required)
 
-`--mode <MODE>`
-Default: compact
+`--mode <MODE>`\
+Default: compact\
 Possible values: compact, light, full
 
-`--solitary`
-Run in solitary mode, without registering with the Icebreakers API
-Conflicts with --secret and --reward-address
+`--solitary`\
+Run in solitary mode, without registering with the Icebreakers API\
+Conflicts with `--secret` and `--reward-address`
 
-`--secret <SECRET>`
-Required unless --solitary is present
-Conflicts with --solitary
-Requires --reward-address
+`--secret <SECRET>`\
+Required unless `--solitary` is present\
+Conflicts with `--solitary`\
+Requires `--reward-address`
 
-`--reward-address <REWARD_ADDRESS>`
-Required unless --solitary is present
-Conflicts with --solitary
-Requires --secret
+`--reward-address <REWARD_ADDRESS>`\
+Required unless `--solitary` is present\
+Conflicts with `--solitary`\
+Requires `--secret`
 
-`--help`
+`--help`\
 Print help information
 
-`--version`
+`--version`\
 Print version information

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -20,6 +20,9 @@ pub enum AppError {
 
     #[error("Server startup error: {0}")]
     Server(String),
+
+    #[error("Load balancer error: {0}")]
+    LoadBalancer(String),
 }
 
 /// Main error type.
@@ -52,6 +55,7 @@ impl From<AppError> for BlockfrostError {
             AppError::Node(e) => Self::internal_server_error(e),
             AppError::Registration(e) => Self::internal_server_error(e),
             AppError::Server(e) => Self::internal_server_error(e),
+            AppError::LoadBalancer(e) => Self::internal_server_error(e),
         }
     }
 }

--- a/src/icebreakers_api.rs
+++ b/src/icebreakers_api.rs
@@ -138,6 +138,11 @@ impl IcebreakersAPI {
                         .flatten()
                         .map(|lb| {
                             if lb.uri.starts_with("//") {
+                                info!(
+                                    "load balancer: falling back to {} for a schemeless load balancer URI: {}",
+                                    fallback_proto,
+                                    lb.uri
+                                );
                                 LoadBalancerConfig {
                                     uri: format!("{}{}", fallback_proto, lb.uri),
                                     ..lb

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod common;
 pub mod errors;
 pub mod health_monitor;
 pub mod icebreakers_api;
+pub mod load_balancer;
 pub mod logging;
 pub mod middlewares;
 pub mod node;

--- a/src/load_balancer.rs
+++ b/src/load_balancer.rs
@@ -1,0 +1,525 @@
+use crate::errors::{AppError, BlockfrostError};
+use crate::server::ApiPrefix;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tracing::{error, info, warn};
+use uuid::Uuid;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct LoadBalancerConfig {
+    pub uri: String,
+    pub access_token: String,
+}
+
+/// It’s slightly less than on the server side to desynchronize
+/// [`LoadBalancerMessage::Ping`] with [`RelayMessage::Ping`]:.
+const WS_PING_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1 * 13);
+
+/// How long we allow Axum to work on a [`JsonRequest`].
+const REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1 * 60);
+
+const MAX_BODY_BYTES: usize = 1 * 1024 * 1024;
+
+/// Whenever a single load balancer connection breaks, we abort all of them.
+/// This logic will have to be better once we actually use more than a single
+/// connection for high availability.
+pub async fn run_all(
+    configs: Vec<LoadBalancerConfig>,
+    http_router: axum::Router,
+    health_errors: Arc<Mutex<Vec<BlockfrostError>>>,
+    api_prefix: ApiPrefix,
+) {
+    let connections: Vec<JoinHandle<Result<(), String>>> = configs
+        .iter()
+        .map(|c| {
+            tokio::spawn(event_loop::run(
+                c.clone(),
+                http_router.clone(),
+                health_errors.clone(),
+                api_prefix.clone(),
+            ))
+        })
+        .collect();
+
+    // Now wait for the first (only?) one to finish, and abort all others, and join all.
+    let (first_res, first_idx, remaining) = futures::future::select_all(connections).await;
+
+    let maybe_error = match first_res {
+        Err(panic) => format!(" with a panic: {:?}", panic),
+        Ok(Err(err)) => format!(" with an error: {}", err),
+        Ok(Ok(())) => "".to_string(),
+    };
+
+    *health_errors.lock().await = vec![
+        AppError::LoadBalancer(format!(
+            "Load balancer connection ended unexpectedly{}",
+            maybe_error
+        ))
+        .into(),
+    ];
+
+    error!(
+        "load balancer: connection to {} finished{}",
+        configs[first_idx].uri, maybe_error
+    );
+
+    warn!(
+        "load balancer: aborting the remaining {} connection(s)",
+        remaining.len()
+    );
+    for r in remaining.iter() {
+        r.abort();
+    }
+
+    let _ignored_failure = futures::future::join_all(remaining).await;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct RequestId(Uuid);
+
+#[derive(Serialize, Deserialize, Debug)]
+struct JsonRequest {
+    id: RequestId,
+    method: JsonRequestMethod,
+    path: String,
+    header: Vec<JsonHeader>,
+    body_base64: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct JsonResponse {
+    id: RequestId,
+    code: u16,
+    header: Vec<JsonHeader>,
+    body_base64: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct JsonHeader {
+    name: String,
+    value: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+enum JsonRequestMethod {
+    GET,
+    POST,
+}
+
+impl JsonRequestMethod {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            JsonRequestMethod::GET => "GET",
+            JsonRequestMethod::POST => "POST",
+        }
+    }
+}
+
+/// The WebSocket messages that we receive.
+#[derive(Serialize, Deserialize, Debug)]
+enum LoadBalancerMessage {
+    Request(JsonRequest),
+    Ping(u64),
+    Pong(u64),
+}
+
+/// The WebSocket messages that we send.
+#[derive(Serialize, Deserialize, Debug)]
+enum RelayMessage {
+    Response(JsonResponse),
+    Ping(u64),
+    Pong(u64),
+}
+
+mod event_loop {
+    use super::*;
+    use futures::stream::{SplitSink, SplitStream};
+    use futures_util::{SinkExt, StreamExt};
+    use tungstenite::protocol::Message;
+
+    /// For clarity, let’s have a single connection 'event_loop per WebSocket
+    /// connection, with the following events:
+    enum LBEvent {
+        NewLoadBalancerMessage(LoadBalancerMessage),
+        NewResponse(JsonResponse),
+        PingTick,
+        SocketError(String),
+    }
+
+    /// Top-level logic of a single WebSocket connection with a load balancer.
+    pub async fn run(
+        config: LoadBalancerConfig,
+        http_router: axum::Router,
+        health_errors: Arc<Mutex<Vec<BlockfrostError>>>,
+        api_prefix: ApiPrefix,
+    ) -> Result<(), String> {
+        let (mut socket_tx, socket_rx) = connect(config.clone()).await?.split();
+        *health_errors.lock().await = vec![];
+
+        let (event_tx, mut event_rx) = mpsc::channel::<LBEvent>(64);
+        let request_task = wire_requests(event_tx.clone(), socket_rx, config.clone()).await;
+
+        let schedule_ping_tick = {
+            let event_tx = event_tx.clone();
+            move || {
+                let tx = event_tx.clone();
+                tokio::spawn(async move {
+                    tokio::time::sleep(WS_PING_TIMEOUT).await;
+                    let _ignored_failure: Result<_, _> = tx.send(LBEvent::PingTick).await;
+                })
+            }
+        };
+
+        // Event loop state (let’s keep it minimal, please):
+        let mut last_ping_sent_at: Option<std::time::Instant> = None;
+        let mut last_ping_id: u64 = 0;
+        let mut loop_error: Result<(), String> = Ok(());
+
+        // Schedule the first `PingTick` immediately, otherwise we won’t start
+        // checking for ping timeout:
+        schedule_ping_tick();
+
+        // The actual connection event loop:
+        'event_loop: while let Some(msg) = event_rx.recv().await {
+            match msg {
+                LBEvent::SocketError(err) => {
+                    loop_error = Err(err);
+                    break 'event_loop;
+                },
+
+                LBEvent::NewLoadBalancerMessage(LoadBalancerMessage::Request(request)) => {
+                    let router = http_router.clone(); // cheap, and Axum also does it for each request
+                    let event_tx = event_tx.clone();
+                    let api_prefix = api_prefix.clone();
+                    tokio::spawn(async move {
+                        let response = handle_one(router, request, api_prefix).await;
+                        let _ignored_failure: Result<_, _> =
+                            event_tx.send(LBEvent::NewResponse(response)).await;
+                    });
+                },
+
+                LBEvent::NewResponse(response) => {
+                    if let Err(err) =
+                        send_json_msg(&mut socket_tx, &RelayMessage::Response(response), &config)
+                            .await
+                    {
+                        loop_error = Err(err);
+                        break 'event_loop;
+                    }
+                },
+
+                LBEvent::NewLoadBalancerMessage(LoadBalancerMessage::Ping(ping_id)) => {
+                    if let Err(err) =
+                        send_json_msg(&mut socket_tx, &RelayMessage::Pong(ping_id), &config).await
+                    {
+                        loop_error = Err(err);
+                        break 'event_loop;
+                    }
+                },
+
+                LBEvent::NewLoadBalancerMessage(LoadBalancerMessage::Pong(pong_id)) => {
+                    if pong_id == last_ping_id {
+                        last_ping_sent_at = None;
+                    }
+                },
+
+                LBEvent::PingTick => {
+                    if let Some(_sent_at) = last_ping_sent_at {
+                        // Ping timeout:
+                        loop_error = Err("ping timeout".to_string());
+                        break 'event_loop;
+                    } else {
+                        // The periodic `PingTick` loop:
+                        schedule_ping_tick();
+                        // Time to send a new ping:
+                        last_ping_id += 1;
+                        last_ping_sent_at = Some(std::time::Instant::now());
+                        if let Err(_) = send_json_msg(
+                            &mut socket_tx,
+                            &LoadBalancerMessage::Ping(last_ping_id),
+                            &config,
+                        )
+                        .await
+                        {
+                            break 'event_loop;
+                        }
+                    }
+                },
+            }
+        }
+
+        // Wait for all children to finish:
+        let children = [request_task];
+        children.iter().for_each(|t| t.abort());
+        futures::future::join_all(children).await;
+
+        loop_error
+    }
+
+    async fn connect(
+        config: LoadBalancerConfig,
+    ) -> Result<
+        tokio_tungstenite::WebSocketStream<
+            tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+        >,
+        String,
+    > {
+        use tungstenite::client::IntoClientRequest;
+        info!("load balancer: connecting to {}", config.uri);
+        let mut request = config.uri.clone().into_client_request().unwrap();
+        request.headers_mut().insert(
+            "Authorization",
+            format!("Bearer {}", config.access_token).parse().unwrap(),
+        );
+        let (ws_stream, _response) = tokio_tungstenite::connect_async(request)
+            .await
+            .map_err(|err| err.to_string())?;
+        info!("load balancer: connected to {}", config.uri);
+        Ok(ws_stream)
+    }
+
+    /// Sends a JSON message to a WebSocket. `Err(_)` is returned when you
+    /// need to break the 'event_loop, because the connection is already broken.
+    async fn send_json_msg<J>(
+        socket_tx: &mut SplitSink<
+            tokio_tungstenite::WebSocketStream<
+                tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+            >,
+            Message,
+        >,
+        msg: &J,
+        config: &LoadBalancerConfig,
+    ) -> Result<(), String>
+    where
+        J: ?Sized + serde::ser::Serialize,
+    {
+        match serde_json::to_string(msg) {
+            Ok(msg) => {
+                match socket_tx.send(Message::Text(msg.into())).await {
+                    Ok(_) => Ok(()),
+                    Err(err) => {
+                        error!(
+                            "load balancer: {}: error when sending a Pong: {:?}",
+                            config.uri, err
+                        );
+                        // Something wrong with the socket, let’s break the 'event_loop:
+                        Err("broken connection with the load balancer".to_string())
+                    },
+                }
+            },
+            Err(err) => {
+                // This branch is practically impossible, but for the sake of completeness:
+                // Let’s break 'event_loop, this seems the most elegant.
+                let err = format!(
+                    "error when serializing request to JSON (this will never happen): {:?}",
+                    err
+                );
+                error!("load balancer: {}: {}", config.uri, err);
+                Err(err)
+            },
+        }
+    }
+
+    async fn wire_requests(
+        event_tx: mpsc::Sender<LBEvent>,
+        mut socket_rx: SplitStream<
+            tokio_tungstenite::WebSocketStream<
+                tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+            >,
+        >,
+        config: LoadBalancerConfig,
+    ) -> JoinHandle<()> {
+        let task = tokio::spawn(async move {
+            'read_loop: loop {
+                match socket_rx.next().await {
+                    None => {
+                        let _ignored_failure: Result<_, _> = event_tx
+                            .send(LBEvent::SocketError("connection closed".to_string()))
+                            .await;
+                        break 'read_loop;
+                    },
+                    Some(Err(err)) => {
+                        let _ignored_failure: Result<_, _> = event_tx
+                            .send(LBEvent::SocketError(format!("stream error: {:?}", err)))
+                            .await;
+                        break 'read_loop;
+                    },
+                    Some(Ok(Message::Close(frame))) => {
+                        warn!(
+                            "load balancer: {}: relay disconnected (CloseFrame: {:?})",
+                            config.uri, frame,
+                        );
+                        let _ignored_failure: Result<_, _> = event_tx
+                            .send(LBEvent::SocketError("relay disconnected".to_string()))
+                            .await;
+                        break 'read_loop;
+                    },
+                    Some(Ok(Message::Frame(_) | Message::Ping(_) | Message::Pong(_))) => {}, // ignore, they’re handled by the library
+                    Some(Ok(Message::Binary(bin))) => {
+                        warn!(
+                            "load balancer: {}: received unexpected binary message: {:?}",
+                            config.uri,
+                            hex::encode(bin),
+                        );
+                    },
+                    Some(Ok(Message::Text(text))) => {
+                        match serde_json::from_str::<LoadBalancerMessage>(&text) {
+                            Ok(msg) => {
+                                if let Err(_) =
+                                    event_tx.send(LBEvent::NewLoadBalancerMessage(msg)).await
+                                {
+                                    break 'read_loop;
+                                }
+                            },
+                            Err(err) => warn!(
+                                "load balancer: {}: received unparsable text message: {:?}: {:?}",
+                                config.uri, text, err,
+                            ),
+                        };
+                    },
+                }
+            }
+        });
+        task
+    }
+
+    /// Passes one [`JsonRequest`] through our underlying original HTTP server.
+    /// Everything happens internally, in memory, without opening new TCP
+    /// connections etc. – very light.
+    async fn handle_one(
+        http_router: axum::Router,
+        request: JsonRequest,
+        api_prefix: ApiPrefix,
+    ) -> JsonResponse {
+        use axum::body::Body;
+        use hyper::StatusCode;
+        use hyper::{Request, Response};
+        use tower::ServiceExt;
+
+        let request_id = request.id.clone();
+        let request_id_ = request.id.clone();
+
+        let rv: Result<JsonResponse, (StatusCode, String)> = async {
+            let req: Request<Body> = json_to_request(request, api_prefix)?;
+
+            let response: Response<Body> =
+                tokio::time::timeout(REQUEST_TIMEOUT, http_router.into_service().oneshot(req))
+                    .await
+                    .map_err(|_elapsed| {
+                        (
+                            StatusCode::GATEWAY_TIMEOUT,
+                            format!(
+                                "Timed out while waiting {:?} for a response",
+                                REQUEST_TIMEOUT
+                            ),
+                        )
+                    })?
+                    .unwrap(); // unwrap is safe, because the error is a non-instantiable [`std::convert::Infallible`]
+
+            response_to_json(response, request_id).await
+        }
+        .await;
+
+        match rv {
+            Ok(ok) => ok,
+            Err((code, err)) => {
+                error!("load balancer: returning {}, because: {}", code, err);
+                JsonResponse {
+                    id: request_id_,
+                    code: code.into(),
+                    header: vec![],
+                    body_base64: err,
+                }
+            },
+        }
+    }
+}
+
+fn json_to_request(
+    json: JsonRequest,
+    api_prefix: ApiPrefix,
+) -> Result<hyper::Request<axum::body::Body>, (hyper::StatusCode, String)> {
+    use axum::body::Body;
+    use hyper::Request;
+    use hyper::StatusCode;
+
+    let body: Body = {
+        if json.body_base64.is_empty() {
+            Body::empty()
+        } else {
+            use base64::{Engine as _, engine::general_purpose};
+            let body_bytes: Vec<u8> =
+                general_purpose::STANDARD
+                    .decode(json.body_base64)
+                    .map_err(|err| {
+                        (
+                            StatusCode::BAD_REQUEST,
+                            format!("Invalid base64 encoding of body_base64: {}", err),
+                        )
+                    })?;
+            Body::from(body_bytes)
+        }
+    };
+
+    let mut rv = Request::builder()
+        .method(json.method.as_str())
+        .uri(format!("{}{}", api_prefix, json.path));
+
+    for h in json.header {
+        rv = rv.header(h.name, h.value);
+    }
+
+    rv.body(body).map_err(|err| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!(
+                "Error when constructing a request from JSON request: {}",
+                err
+            ),
+        )
+    })
+}
+
+async fn response_to_json(
+    response: hyper::Response<axum::body::Body>,
+    request_id: RequestId,
+) -> Result<JsonResponse, (hyper::StatusCode, String)> {
+    use hyper::StatusCode;
+
+    let header: Vec<JsonHeader> = response
+        .headers()
+        .iter()
+        .flat_map(|(name, value)| {
+            value.to_str().ok().map(|value| JsonHeader {
+                name: name.to_string(),
+                value: value.to_string(),
+            })
+        })
+        .collect();
+
+    let code: u16 = response.status().into();
+
+    let body_base64: String = {
+        let body = response.into_body();
+        let body_bytes = axum::body::to_bytes(body, MAX_BODY_BYTES)
+            .await
+            .map_err(|err| {
+                (
+                    StatusCode::BAD_GATEWAY,
+                    format!("Cannot read body of the response: {}", err),
+                )
+            })?;
+        use base64::{Engine as _, engine::general_purpose};
+        general_purpose::STANDARD.encode(body_bytes)
+    };
+
+    Ok(JsonResponse {
+        id: request_id,
+        code,
+        header,
+        body_base64,
+    })
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -13,9 +13,20 @@ use axum::{
     routing::{get, post},
 };
 use std::sync::Arc;
-use tower::ServiceBuilder;
-use tower_http::normalize_path::{NormalizePath, NormalizePathLayer};
+use tower_http::normalize_path::NormalizePathLayer;
 use uuid::Uuid;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ApiPrefix(pub Option<Uuid>);
+
+impl std::fmt::Display for ApiPrefix {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.0 {
+            Some(uuid) => write!(f, "/{}", uuid),
+            None => write!(f, "/"),
+        }
+    }
+}
 
 /// Builds and configures the Axum `Router`.
 /// Returns `Ok(Router)` on success or an `AppError` if a step fails.
@@ -23,10 +34,11 @@ pub async fn build(
     config: Arc<Config>,
 ) -> Result<
     (
-        NormalizePath<Router>,
+        Router,
         NodePool,
+        health_monitor::HealthMonitor,
         Option<Arc<IcebreakersAPI>>,
-        String,
+        ApiPrefix,
     ),
     AppError,
 > {
@@ -56,11 +68,7 @@ pub async fn build(
     let health_monitor = health_monitor::HealthMonitor::spawn(node_conn_pool.clone()).await;
 
     // Build a prefix
-    let api_prefix = if config.icebreakers_config.is_some() {
-        format!("/{}", Uuid::new_v4())
-    } else {
-        "/".to_string()
-    };
+    let api_prefix = ApiPrefix(config.icebreakers_config.as_ref().map(|_| Uuid::new_v4()));
 
     // Set up optional Icebreakers API (solitary option in CLI)
     let icebreakers_api = IcebreakersAPI::new(&config, api_prefix.clone()).await?;
@@ -86,19 +94,21 @@ pub async fn build(
     };
 
     // Nest under the UUID prefix
-    let api_routes = if api_prefix == "/" || api_prefix.is_empty() {
+    let api_routes: Router = if api_prefix.0.is_none() {
         regular_api_routes.merge(hidden_api_routes)
     } else {
-        regular_api_routes
-            .clone()
-            .nest(&api_prefix, regular_api_routes.merge(hidden_api_routes))
+        // XXX: using `.nest()` breaks trailing slashes, we need `.nest_service()`:
+        regular_api_routes.clone().nest_service(
+            &api_prefix.to_string(),
+            regular_api_routes.merge(hidden_api_routes),
+        )
     };
 
     // Add layers
     let app = {
         let mut rv = api_routes
             .layer(Extension(config))
-            .layer(Extension(health_monitor))
+            .layer(Extension(health_monitor.clone()))
             .layer(Extension(node_conn_pool.clone()))
             .layer(from_fn(error_middleware))
             .fallback(BlockfrostError::not_found_with_uri);
@@ -109,9 +119,13 @@ pub async fn build(
     };
 
     // Final layers (e.g., trim trailing slash)
-    let app = ServiceBuilder::new()
-        .layer(NormalizePathLayer::trim_trailing_slash())
-        .service(app);
+    let app = app.layer(NormalizePathLayer::trim_trailing_slash());
 
-    Ok((app, node_conn_pool, icebreakers_api, api_prefix))
+    Ok((
+        app,
+        node_conn_pool,
+        health_monitor,
+        icebreakers_api,
+        api_prefix,
+    ))
 }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -3,14 +3,14 @@ use blockfrost::{BlockFrostSettings, BlockfrostAPI};
 use blockfrost_platform::{
     AppError, NodePool,
     cli::{Config, IcebreakersConfig, LogLevel, Mode, Network},
+    health_monitor,
     icebreakers_api::IcebreakersAPI,
-    server::build,
+    server::{ApiPrefix, build},
 };
 use std::{
     env,
     sync::{Arc, LazyLock},
 };
-use tower_http::normalize_path::NormalizePath;
 
 static INIT_LOGGING: LazyLock<()> = LazyLock::new(|| {
     tracing_subscriber::fmt::init();
@@ -50,10 +50,11 @@ pub fn test_config(icebreakers_config: Option<IcebreakersConfig>) -> Arc<Config>
 
 pub async fn build_app() -> Result<
     (
-        NormalizePath<Router>,
+        Router,
         NodePool,
+        health_monitor::HealthMonitor,
         Option<Arc<IcebreakersAPI>>,
-        String,
+        ApiPrefix,
     ),
     AppError,
 > {
@@ -64,10 +65,11 @@ pub async fn build_app() -> Result<
 
 pub async fn build_app_non_solitary() -> Result<
     (
-        NormalizePath<Router>,
+        Router,
         NodePool,
+        health_monitor::HealthMonitor,
         Option<Arc<IcebreakersAPI>>,
-        String,
+        ApiPrefix,
     ),
     AppError,
 > {

--- a/tests/endpoints_test.rs
+++ b/tests/endpoints_test.rs
@@ -28,7 +28,7 @@ mod tests {
     async fn test_route_root() {
         initialize_logging();
 
-        let (app, _, _, _) = build_app().await.expect("Failed to build the application");
+        let (app, _, _, _, _) = build_app().await.expect("Failed to build the application");
 
         let response = app
             .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
@@ -54,7 +54,7 @@ mod tests {
     async fn test_route_metrics() {
         initialize_logging();
 
-        let (app, _, _, _) = build_app().await.expect("Failed to build the application");
+        let (app, _, _, _, _) = build_app().await.expect("Failed to build the application");
 
         let response = app
             .oneshot(
@@ -81,7 +81,7 @@ mod tests {
     #[tokio::test]
     async fn test_route_submit_cbor_error() {
         initialize_logging();
-        let (app, _, _, _) = build_app().await.expect("Failed to build the application");
+        let (app, _, _, _, _) = build_app().await.expect("Failed to build the application");
 
         let tx = "AAAAAA";
 
@@ -113,7 +113,7 @@ mod tests {
     #[tokio::test]
     async fn test_route_submit_error() {
         initialize_logging();
-        let (app, _, _, _) = build_app().await.expect("Failed to build the application");
+        let (app, _, _, _, _) = build_app().await.expect("Failed to build the application");
 
         let tx = "84a300d90102818258205176274bef11d575edd6aa72392aaf993a07f736e70239c1fb22d4b1426b22bc01018282583900ddf1eb9ce2a1561e8f156991486b97873fb6969190cbc99ddcb3816621dcb03574152623414ed354d2d8f50e310f3f2e7d167cb20e5754271a003d09008258390099a5cb0fa8f19aba38cacf8a243d632149129f882df3a8e67f6bd512bcb0cde66a545e9fbc7ca4492f39bca1f4f265cc1503b4f7d6ff205c1b000000024f127a7c021a0002a2ada100d90102818258208b83e59abc9d7a66a77be5e0825525546a595174f8b929f164fcf5052d7aab7b5840709c64556c946abf267edd90b8027343d065193ef816529d8fa7aa2243f1fd2ec27036a677974199e2264cb582d01925134b9a20997d5a734da298df957eb002f5f6";
 
@@ -156,7 +156,7 @@ mod tests {
     #[tokio::test]
     async fn test_route_submit_agent_dequeu() {
         initialize_logging();
-        let (app, _, _, _) = build_app().await.expect("Failed to build the application");
+        let (app, _, _, _, _) = build_app().await.expect("Failed to build the application");
 
         let tx = "84a800848258204c16d304e6d531c59afd87a9199b7bb4175bc131b3d6746917901046b662963c00825820893c3f630c0b2db16d041c388aa0d58746ccbbc44133b2d7a3127a72c79722f1018258200998adb591c872a241776e39fe855e04b2d7c361008e94c582f59b6b6ccc452c028258208380ce7240ba59187f6450911f74a70cf3d2749228badb2e7cd10fb6499355f503018482581d61e15900a9a62a8fb01f936a25bf54af209c7ed1248c4e5abd05ec4e76821a0023ba63a1581ca0028f350aaabe0545fdcb56b039bfb08e4bb4d8c4d7c3c7d481c235a145484f534b5900a300581d71cba5c6770fe7b30ebc1fa32f01938c150513211360ded23ac76e36b301821a006336d5a3581c239075b83c03c2333eacd0b0beac6b8314f11ce3dc0c047012b0cad4a144706f6f6c01581c3547b4325e495d529619335603ababde10025dceafa9ed34b1fb6611a158208b284793d3bd4967244a2ddd68410d56d06d36ac8d201429b937096a2e8234bc1b7ffffffffffade6b581ca0028f350aaabe0545fdcb56b039bfb08e4bb4d8c4d7c3c7d481c235a145484f534b59195e99028201d818583ad8799fd8799f4040ffd8799f581ca0028f350aaabe0545fdcb56b039bfb08e4bb4d8c4d7c3c7d481c23545484f534b59ff1a006336d5195e99ff825839016d06090559d8ed2988aa5b2fff265d668cf552f4f62278c0128f816c0a48432e080280d0d9b15edb65563995f97ce236035afea568e660d1821a00118f32a1581c2f8b2d1f384485896f38406173fa11df2a4ce53b4b0886138b76597aa1476261746368657201825839016d06090559d8ed2988aa5b2fff265d668cf552f4f62278c0128f816c0a48432e080280d0d9b15edb65563995f97ce236035afea568e660d11a06d9f713021a000ab9e00b582027f17979d848d6472896266dd8bf39f7251ca23798713464bc407bf637286c230d81825820cf5de9189b958f8ad64c1f1837c2fa4711d073494598467a1c1a59589393eae20310825839016d06090559d8ed2988aa5b2fff265d668cf552f4f62278c0128f816c0a48432e080280d0d9b15edb65563995f97ce236035afea568e660d11a08666c75111a001016d01282825820bf93dc59c10c19c35210c2414779d7391ca19128cc7b13794ea85af5ff835f59008258201c37df764f8261edce8678b197767668a91d544b2b203fb5d0cf9acc10366e7600a200818258200eabfa083d7969681d2fc8e825a5f79e1c40f03aeac46ecd94bf5c5790db1bc058409a029ddd3cdde65598bb712c640ea63eeebfee526ce49bd0983b4d1fdca858481ddf931bf0354552cc0a7d3365e2f03fdb457c0466cea8b371b645f9b6d0c2010582840001d8799fd8799f011a006336d5195e991b7ffffffffffade6bd8799f1a000539e7ff01ffff821a000b46e41a0a7f3ca4840003d87d80821a002dccfe1a28868be8f5f6";
 
@@ -186,7 +186,7 @@ mod tests {
     #[tokio::test]
     async fn test_route_submit_success() {
         initialize_logging();
-        let (app, _, _, _) = build_app().await.expect("Failed to build the application");
+        let (app, _, _, _, _) = build_app().await.expect("Failed to build the application");
         let blockfrost_client = get_blockfrost_client();
         let tx = build_tx(&blockfrost_client).await.unwrap();
 
@@ -221,7 +221,7 @@ mod tests {
     async fn test_icebreakers_registrations() -> Result<(), Box<dyn std::error::Error>> {
         initialize_logging();
 
-        let (app, _, icebreakers_api, api_prefix) = build_app_non_solitary()
+        let (app, _, _, icebreakers_api, api_prefix) = build_app_non_solitary()
             .await
             .expect("Failed to build the application");
 


### PR DESCRIPTION
Resolves #178

## Context

- #178

- The server-side PR (`8 files changed, 1220 insertions(+), 71 deletions(-)`) is in the second repository.

## The new (additional) flow

1. In non-solitary mode, when registering with the `blockfrost-icebreakers-api`, the `blockfrost-platform` gets an additional field in the successful response, with a list of load balancers to connect to:

   ```json
   {
     "route": "b0be51e5-e5fe-4e42-98a9-2246173bea19",
     "load_balancers": [
       {
         "uri": "ws://127.0.0.1:3001/ws",
         "access_token": "QNo3SYA0iPY+LfEhb2Gi5NaUOXqLw4b7ZQyg9DL4hFs="
       }
     ]
   }
   ```

2. Currently, this new WebSocket endpoint is served by the same IceBreakers API, because we already have it set up. So it’s easiest to run it there for the initial testing. But this part can easily be extracted, and run elsewhere, perhaps on more than one machine for redundancy.

3. `blockfrost-platform` then connects to the WebSocket endpoint, and sets `Authorization: Bearer <access_token>`.

4. Both sides exchange `Ping` and `Pong` messages continuously, which allows us to detect the other side going offline quite quickly, even with a `-j DROP`. And also to measure the pure network round-trip time, without the overhead of any advanced calculations.

5. The load balancer code exposes a `GET /stats` endpoint, where you can see all currently connected IceBreakers:

   ```json
   ❯ curl -fsSL http://icebreakers_api:3001/stats | jq .
   {
     "IcebreakerX": {
       "api_prefix": "b0be51e5-e5fe-4e42-98a9-2246173bea19",
       "network_rtt_seconds": 0.000387182,
       "connected_since": "2025-03-28T19:09:46.399124184Z",
       "requests_sent": 0,
       "responses_received": 0,
       "requests_in_progress": 0
     }
   }
   ```

6. But a more important new route in the load balancer (currently running as part of the IceBreakers API) is `GET /{api_prefix}/{path}`, and `POST /{api_prefix}/{path}`:

   1. Using the example above, once you issue, say: `curl -fsSL https://icebreakers-api.blockfrost.io/b0be51e5-e5fe-4e42-98a9-2246173bea19/`,
   2. this request will be translated into a JSON message, and sent over the WebSocket connection with IcebreakerX (identified by its `api_prefix`):

      ```json
      {
        "id": "04810b96-87cd-4af0-8c1b-7b5e00806769",
        "method": "GET",
        "path": "/",
        "header": [
          {
            "name": "host",
            "value": "0.0.0.0:3001"
          },
          {
            "name": "user-agent",
            "value": "curl/8.11.1"
          },
          {
            "name": "accept",
            "value": "*/*"
          }
        ],
        "body_base64": ""
      }
      ```
   3. Then this particular `blockfrost-platform` will resolve the request against its local `axum::Router` – all cheap, and in memory, without opening any new TCP connections to itself.
   4. The response is encoded back into a JSON response message, and sent over the WebSocket to the load balancer:

      ```json
      {
        "id": "04810b96-87cd-4af0-8c1b-7b5e00806769",
        "code": 200,
        "header": [
          {
            "name": "content-type",
            "value": "application/json"
          },
          {
            "name": "content-length",
            "value": "241"
          }
        ],
        "body_base64": "eyJuYW1lIjoiYmxvY2tmcm9zdC1wbGF0Zm9ybSIsInZlcnNpb24iOiIwLjAuMiIsInJldmlzaW9uIjoiZGlydHkiLCJoZWFsdGh5Ijp0cnVlLCJub2RlX2luZm8iOnsiYmxvY2siOiIyNjkzZTk1M2M4NmU0NzZlNGZhMmFhYWY2MDZjZWRjOThhZmU1ZjEwZTFhZDViYTk3NmNmZDkxNzI4NGI4MGJiIiwiZXBvY2giOjg4NSwiZXJhIjo2LCJzbG90Ijo3NjU0MjI5Niwic3luY19wcm9ncmVzcyI6OTkuOTV9LCJlcnJvcnMiOltdfQ=="
      }
      ```
   5. Which in turn converts it to a `hyper::Response`, and sends it to the end user.
   6. All `GET` and `POST` requests will work. It’s been tested to successfully submit a new transaction.

   Example:

   ```json
   ❯ curl -fsSL http://icebreakers_api:3001/b0be51e5-e5fe-4e42-98a9-2246173bea19/ | jq .
   {
     "name": "blockfrost-platform",
     "version": "0.0.2",
     "revision": "dirty",
     "healthy": true,
     "node_info": {
       "block": "6d87f87a0642fd4a59bb8af89400e8c7a777e290d2c2e02ceb93059ac7b4aaba",
       "epoch": 885,
       "era": 6,
       "slot": 76533840,
       "sync_progress": 100.0
     },
     "errors": []
   }
   ```

7. The “old” `blockfrost-platform` API remains as-is on port 3000. After the WebSocket testing period it will no longer need to be open to the public, or have a UUID `api_prefix`.

8. For the time being, by using the same UUID v4 prefix structure to communicate with a particular `blockfrost-platform`, it’s enough to just replace its IP address part of the URL with https://icebreakers-api.blockfrost.io – keeping the request path, body, headers etc. the same.
