### PR TITLE
chore: expose a `health_errors_total` gauge in metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Added
+
+- Expose a `health_errors_total` gauge in metrics
+
 ## [0.0.2] - 2025-03-20
 
 ### Changed

--- a/src/health_monitor.rs
+++ b/src/health_monitor.rs
@@ -32,6 +32,11 @@ impl HealthMonitor {
         }
     }
 
+    /// Gets the number of currently happening errors for Prometheus metrics.
+    pub async fn num_errors(&self) -> u32 {
+        Self::collect_errors(&self.sources.lock().await).await.len() as u32
+    }
+
     /// Collect errors across multiple sources.
     async fn collect_errors(sources: &[Arc<Mutex<Vec<BlockfrostError>>>]) -> Vec<BlockfrostError> {
         let mut errors = vec![];


### PR DESCRIPTION
## Context

* SPOs set up alerts for changes in `GET /metrics`.

* So let’s add a link between the number of health errors in `GET /` and the response in `GET /metrics`.

* After a Grafana alert for the `health_errors_total` gauge, an SPO can look at `GET /` or the logs manually.