### PR TITLE
Remove unused cbor crate dependency to fix failing build on Rust 1.86.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,6 @@ dependencies = [
  "blockfrost-openapi",
  "bzip2",
  "cardano-serialization-lib",
- "cbor",
  "chrono",
  "clap",
  "crossbeam",
@@ -452,12 +451,6 @@ name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
-
-[[package]]
-name = "byteorder"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
 
 [[package]]
 name = "byteorder"
@@ -524,16 +517,6 @@ dependencies = [
  "serde_json",
  "sha2 0.9.9",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "cbor"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e56053652b4b5c0ded5ae6183c7cd547ad2dd6bcce149658bef052a4995533bd"
-dependencies = [
- "byteorder 0.5.3",
- "rustc-serialize",
 ]
 
 [[package]]
@@ -1233,7 +1216,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
- "byteorder 1.5.0",
+ "byteorder",
 ]
 
 [[package]]
@@ -2383,7 +2366,7 @@ name = "pallas-network"
 version = "0.32.0"
 source = "git+https://github.com/blockfrost/pallas.git?rev=f74c49e409570e7835a424bd20ad0cf9e86e0efb#f74c49e409570e7835a424bd20ad0cf9e86e0efb"
 dependencies = [
- "byteorder 1.5.0",
+ "byteorder",
  "hex",
  "itertools 0.13.0",
  "pallas-codec",
@@ -3114,12 +3097,6 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-serialize"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe834bc780604f4674073badbad26d7219cadfb4a2275802db12cbae17498401"
 
 [[package]]
 name = "rustc_version"
@@ -4765,7 +4742,7 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
- "byteorder 1.5.0",
+ "byteorder",
  "zerocopy-derive",
 ]
 
@@ -4836,7 +4813,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
 dependencies = [
  "aes",
- "byteorder 1.5.0",
+ "byteorder",
  "bzip2",
  "constant_time_eq",
  "crc32fast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ pallas-hardano = { git = "https://github.com/blockfrost/pallas.git", rev = "f74c
 pallas-validate = { git = "https://github.com/blockfrost/pallas.git", rev = "f74c49e409570e7835a424bd20ad0cf9e86e0efb" }
 reqwest = "0.12.12"
 hex = "0.4.3"
-cbor = "0.4.1"
 metrics = { version = "0.24.1", default-features = false }
 metrics-exporter-prometheus = { version = "0.16.1", default-features = false }
 metrics-process = "2.4.0"


### PR DESCRIPTION
Resolves https://github.com/blockfrost/blockfrost-platform/issues/269