### PR TITLE
chore: add a NixOS service for `cardano-parts`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -100,6 +100,15 @@
             targetSystem: import ./nix/internal/linux-cross-arm64.nix {inherit inputs targetSystem;}
           );
 
+        nixosModule = {
+          pkgs,
+          lib,
+          ...
+        }: {
+          imports = [./nix/nixos];
+          services.blockfrost-platform.package = lib.mkDefault inputs.self.packages.${pkgs.system}.default;
+        };
+
         hydraJobs = let
           crossSystems = ["x86_64-windows" "aarch64-linux"];
           allJobs = {

--- a/nix/nixos/blockfrost-platform.nix
+++ b/nix/nixos/blockfrost-platform.nix
@@ -1,0 +1,92 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib) types;
+  cfg = config.services.blockfrost-platform;
+in {
+  options = {
+    services.blockfrost-platform = {
+      enable = lib.mkEnableOption "enable the blockfrost-platform service";
+      args = lib.mkOption {
+        description = "Command-line arguments to launch the blockfrost-platform.";
+        type = types.listOf types.str;
+        default =
+          (
+            if cfg.secretConfig != null
+            then ["--config" cfg.secretConfig]
+            else ["--solitary"]
+          )
+          ++ ["--server-address" cfg.serverAddr]
+          ++ ["--server-port" (toString cfg.port)]
+          ++ ["--network" cfg.network]
+          ++ ["--log-level" cfg.logLevel]
+          ++ ["--node-socket-path" cfg.nodeSocket]
+          ++ ["--mode" cfg.mode];
+      };
+      secretConfig = lib.mkOption {
+        type = types.nullOr (types.either types.str types.path);
+        description = ''
+          Path to a config file with secrets of the following form:
+
+          ```
+          reward_address = "addr1…"
+          secret = "00000000000000000000000000000000"
+          ```
+
+          If it’s not defined, `--solitary` mode will be used.
+        '';
+        default = null;
+      };
+      nodeSocket = lib.mkOption {
+        type = types.nullOr (types.either types.str types.path);
+        description = "Path to the cardano-node socket.";
+      };
+      port = lib.mkOption {
+        type = types.int;
+        default = 3000;
+        description = "The port number.";
+      };
+      serverAddr = lib.mkOption {
+        type = types.str;
+        default = "0.0.0.0";
+        description = "The host address to bind to.";
+      };
+      logLevel = lib.mkOption {
+        type = types.enum ["debug" "info" "warn" "error" "trace"];
+        default = "info";
+      };
+      mode = lib.mkOption {
+        type = types.enum ["compact" "light" "full"];
+        default = "compact";
+        description = "This doesn’t mean anything yet.";
+      };
+      network = lib.mkOption {
+        type = types.enum ["mainnet" "preprod" "preview"];
+        default = "mainnet";
+      };
+      package = lib.mkOption {
+        type = types.package;
+        default = pkgs.blockfrost-platform;
+      };
+    };
+  };
+  config = lib.mkIf cfg.enable {
+    systemd.services.blockfrost-platform = {
+      wantedBy = ["multi-user.target"];
+      serviceConfig = {
+        Type = "simple";
+        Restart = "always";
+        RestartSec = 5;
+        DynamicUser = true;
+        ExecStart = lib.escapeShellArgs ([(lib.getExe cfg.package)] ++ cfg.args);
+      };
+      environment = {
+        # For `dirs::config_dir()`:
+        XDG_CONFIG_HOME = pkgs.emptyDirectory;
+      };
+    };
+  };
+}

--- a/nix/nixos/default.nix
+++ b/nix/nixos/default.nix
@@ -1,0 +1,3 @@
+{
+  imports = import ./module-list.nix;
+}

--- a/nix/nixos/module-list.nix
+++ b/nix/nixos/module-list.nix
@@ -1,0 +1,3 @@
+[
+  ./blockfrost-platform.nix
+]


### PR DESCRIPTION
Related to #272

## Context

`cardano-parts` will depend on this NixOS service definition in:
* https://github.com/input-output-hk/cardano-parts/pull/62

## ~~Warning~~

~~I’m not sure about the `cardano-` prefix (`cardano-blockfrost-platform`), but this is what `cardano-parts` do everywhere. Will ask @johnalotoski.~~

~~Hm, actually, they don’t to that for [`cardano-foundation/blockperf`](https://github.com/cardano-foundation/blockperf). 🤔~~