### PR TITLE
fix: don’t panic when there are no load balancers; warn instead

### DIFF
--- a/src/load_balancer.rs
+++ b/src/load_balancer.rs
@@ -32,6 +32,11 @@ pub async fn run_all(
     health_errors: Arc<Mutex<Vec<BlockfrostError>>>,
     api_prefix: ApiPrefix,
 ) {
+    assert!(
+        !configs.is_empty(),
+        "load_balancer::run_all called with no configs - nothing to run!"
+    );
+
     let connections: Vec<JoinHandle<Result<(), String>>> = configs
         .iter()
         .map(|c| {


### PR DESCRIPTION
## Context

It’s not a serious issue, because the panic just kills a background task which already registered with IceBreakers.

So this PR has exactly the same behavior, but much cleaner, and less scary logs.