### PR TITLE
fix: set the `RUST_SRC_PATH` correctly for LSP (`rust-analyzer`) in the devshell

### DIFF
--- a/nix/devshells.nix
+++ b/nix/devshells.nix
@@ -72,6 +72,10 @@ in {
         name = "TESTGEN_HS_PATH";
         value = lib.getExe internal.testgen-hs;
       }
+      {
+        name = "RUST_SRC_PATH";
+        value = "${internal.rustPackages.rust-src}/lib/rustlib/src/rust/library";
+      }
     ]
     ++ lib.optionals pkgs.stdenv.isDarwin [
       {


### PR DESCRIPTION
## Context

I noticed that jump-to-def didn’t work reliably for Rust’s standard library files.

Let’s point `rust-analyzer` to the same exact standard library that we’re building with.