### PR TITLE
chore: add Dolos to the devshell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -85,6 +85,23 @@
         "type": "github"
       }
     },
+    "dolos": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1751915048,
+        "narHash": "sha256-GKSSOfxqx0TqW0RpB4+0Bv1J5jJRqYviQ3zrRbkBoy4=",
+        "owner": "txpipe",
+        "repo": "dolos",
+        "rev": "42d955835d9c210af1f5ab270ca1d31182511bde",
+        "type": "github"
+      },
+      "original": {
+        "owner": "txpipe",
+        "ref": "v0.26.0",
+        "repo": "dolos",
+        "type": "github"
+      }
+    },
     "fenix": {
       "inputs": {
         "nixpkgs": [
@@ -211,6 +228,7 @@
         "cardano-playground": "cardano-playground",
         "crane": "crane",
         "devshell": "devshell",
+        "dolos": "dolos",
         "fenix": "fenix",
         "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",

--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,8 @@
     flake-compat.flake = false;
     cardano-node.url = "github:IntersectMBO/cardano-node/10.4.1";
     cardano-node.flake = false; # otherwise, +2k dependencies we don’t really use
+    dolos.url = "github:txpipe/dolos/v0.26.0";
+    dolos.flake = false;
     testgen-hs.url = "github:input-output-hk/testgen-hs/10.4.1.1"; # make sure it follows cardano-node
     testgen-hs.flake = false; # otherwise, +2k dependencies we don’t really use
     devshell.url = "github:numtide/devshell";

--- a/nix/devshells.nix
+++ b/nix/devshells.nix
@@ -30,10 +30,13 @@ in {
       name = "cardano-address";
       package = internal.cardano-address;
     }
+    {package = internal.dolos;}
     {package = pkgs.cargo-nextest;}
     {package = pkgs.cargo-tarpaulin;}
-    {package = internal.rustPackages.cargo;}
-    {package = internal.rustPackages.clippy;}
+    {
+      name = "cargo";
+      package = internal.rustPackages.cargo;
+    }
     {package = internal.rustPackages.rust-analyzer;}
     {
       category = "handy";
@@ -90,7 +93,10 @@ in {
 
   devshell = {
     packages =
-      [pkgs.unixtools.xxd]
+      [
+        pkgs.unixtools.xxd
+        internal.rustPackages.clippy
+      ]
       ++ lib.optionals pkgs.stdenv.isLinux [
         pkgs.pkg-config
       ]

--- a/nix/internal/unix.nix
+++ b/nix/internal/unix.nix
@@ -335,4 +335,34 @@ in
         chmod +x $out/*.sh
         shellcheck $out/*.sh
       '';
+
+    dolos =
+      craneLib.buildPackage
+      {
+        src = inputs.dolos;
+        strictDeps = true;
+        nativeBuildInputs =
+          [pkgs.gnum4]
+          ++ lib.optionals pkgs.stdenv.isLinux [
+            pkgs.pkg-config
+          ];
+        buildInputs =
+          lib.optionals pkgs.stdenv.isLinux [
+            pkgs.openssl
+          ]
+          ++ lib.optionals pkgs.stdenv.isDarwin [
+            pkgs.libiconv
+            pkgs.darwin.apple_sdk_12_3.frameworks.SystemConfiguration
+            pkgs.darwin.apple_sdk_12_3.frameworks.Security
+            pkgs.darwin.apple_sdk_12_3.frameworks.CoreFoundation
+          ];
+        meta = {
+          mainProgram = "dolos";
+          description = "Cardano Data Node";
+        };
+      }
+      // lib.optionalAttrs pkgs.stdenv.isDarwin {
+        # for bindgen, used by libproc, used by metrics_process
+        LIBCLANG_PATH = "${lib.getLib pkgs.llvmPackages.libclang}/lib";
+      };
   }


### PR DESCRIPTION
## Context

Since we're integrating Dolos (e.g. #344), it’s convenient to have it in the `devshell`.

The same derivation can be used for the Desktop app (https://github.com/blockfrost/blockfrost-platform-desktop/issues/3), and the GitHub runner (https://github.com/blockfrost/blockfrost-ops/issues/1877).