### PR TITLE
fix: `dmgbuild` volume permissions on macOS Sonoma+

### DIFF
--- a/nix/internal/darwin.nix
+++ b/nix/internal/darwin.nix
@@ -529,7 +529,10 @@ in
         rev = "cdf7ba052fcd09f60132af183ce2b1388566cc75";
         hash = "sha256-QkVEECnUmEROZNzczKHLYTjSyoLz3V8v2uhuJWntgog=";
       };
-      patches = [./dmgbuild--force-badge.diff];
+      patches = [
+        ./dmgbuild--force-badge.diff
+        ./dmgbuild--tmp-mount-root.diff
+      ];
       buildInputs = with pkgs; [apple-sdk_11 (darwinMinVersionHook "11.0")];
       propagatedBuildInputs = (with pythonPackages; [setuptools]) ++ [ds_store pyobjc.framework-Quartz];
       format = "pyproject";

--- a/nix/internal/dmgbuild--tmp-mount-root.diff
+++ b/nix/internal/dmgbuild--tmp-mount-root.diff
@@ -1,0 +1,16 @@
+diff --git a/src/dmgbuild/core.py b/src/dmgbuild/core.py
+index 5fbe9be..2aa5d1f 100644
+--- a/src/dmgbuild/core.py
++++ b/src/dmgbuild/core.py
+@@ -502,8 +502,10 @@ def build_dmg(  # noqa; C901
+     # IDME was deprecated in macOS 10.15/Catalina; as a result, use of -noidme
+     # started raising a warning.
+     if MACOS_VERSION >= (10, 15):
++        # For Sonoma+:
++        mount_root = os.environ.get("TMPDIR", tempfile.gettempdir())
+         ret, output = hdiutil(
+-            "attach", "-nobrowse", "-owners", "off", writableFile.name
++            "attach", "-nobrowse", "-mountroot", mount_root, "-owners", "off", writableFile.name
+         )
+     else:
+         ret, output = hdiutil(


### PR DESCRIPTION
## Context

This is a little cryptic, but on newer macOS, `hdiutil` mounting the DMG under `/Volumes/*` (while building it) prevents `ditto` from copying the app onto the DMG.

Unless you mount under `$TMPDIR`.