### PR TITLE
chore: prepare for the 0.0.3 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,7 +445,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33415e24172c1b7d6066f6d999545375ab8e1d95421d6784bdfff9496f292387"
 dependencies = [
  "bitcoin_hashes",
- "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
 ]
@@ -570,13 +569,13 @@ dependencies = [
  "node",
  "ntest",
  "pallas",
- "pallas-addresses",
- "pallas-codec",
- "pallas-crypto",
- "pallas-hardano",
- "pallas-network",
- "pallas-primitives",
- "pallas-traverse",
+ "pallas-addresses 1.0.0-alpha.2",
+ "pallas-codec 1.0.0-alpha.2",
+ "pallas-crypto 1.0.0-alpha.2",
+ "pallas-hardano 1.0.0-alpha.2",
+ "pallas-network 1.0.0-alpha.2",
+ "pallas-primitives 1.0.0-alpha.2",
+ "pallas-traverse 1.0.0-alpha.2",
  "pretty_assertions",
  "proptest",
  "reqwest",
@@ -839,8 +838,8 @@ dependencies = [
  "futures-util",
  "hex",
  "inquire",
- "pallas-addresses",
- "pallas-network",
+ "pallas-addresses 1.0.0-alpha.1",
+ "pallas-network 1.0.0-alpha.1",
  "pretty_assertions",
  "reqwest",
  "rstest",
@@ -2397,12 +2396,12 @@ dependencies = [
  "hex",
  "metrics",
  "num_cpus",
- "pallas-codec",
- "pallas-crypto",
- "pallas-hardano",
- "pallas-network",
- "pallas-primitives",
- "pallas-traverse",
+ "pallas-codec 1.0.0-alpha.1",
+ "pallas-crypto 1.0.0-alpha.1",
+ "pallas-hardano 1.0.0-alpha.1",
+ "pallas-network 1.0.0-alpha.1",
+ "pallas-primitives 1.0.0-alpha.1",
+ "pallas-traverse 1.0.0-alpha.1",
  "reqwest",
  "serde",
  "serde_json",
@@ -2670,16 +2669,16 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "pallas"
-version = "1.0.0-alpha.1"
-source = "git+https://github.com/blockfrost/pallas.git?tag=blockfrost-platform-0.0.3-alpha2#fa233715b67b22fd8b191c9294858a3185e1207b"
+version = "1.0.0-alpha.2"
+source = "git+https://github.com/blockfrost/pallas.git?tag=blockfrost-platform-0.0.3-alpha4#eadd97143a13d153d18a7b2ee2de3ff32a9494e8"
 dependencies = [
- "pallas-addresses",
- "pallas-codec",
+ "pallas-addresses 1.0.0-alpha.2",
+ "pallas-codec 1.0.0-alpha.2",
  "pallas-configs",
- "pallas-crypto",
- "pallas-network",
- "pallas-primitives",
- "pallas-traverse",
+ "pallas-crypto 1.0.0-alpha.2",
+ "pallas-network 1.0.0-alpha.2",
+ "pallas-primitives 1.0.0-alpha.2",
+ "pallas-traverse 1.0.0-alpha.2",
  "pallas-txbuilder",
  "pallas-utxorpc",
  "pallas-validate",
@@ -2695,8 +2694,23 @@ dependencies = [
  "crc",
  "cryptoxide",
  "hex",
- "pallas-codec",
- "pallas-crypto",
+ "pallas-codec 1.0.0-alpha.1",
+ "pallas-crypto 1.0.0-alpha.1",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "pallas-addresses"
+version = "1.0.0-alpha.2"
+source = "git+https://github.com/blockfrost/pallas.git?tag=blockfrost-platform-0.0.3-alpha4#eadd97143a13d153d18a7b2ee2de3ff32a9494e8"
+dependencies = [
+ "base58",
+ "bech32 0.9.1",
+ "crc",
+ "cryptoxide",
+ "hex",
+ "pallas-codec 1.0.0-alpha.2",
+ "pallas-crypto 1.0.0-alpha.2",
  "thiserror 1.0.69",
 ]
 
@@ -2712,15 +2726,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallas-codec"
+version = "1.0.0-alpha.2"
+source = "git+https://github.com/blockfrost/pallas.git?tag=blockfrost-platform-0.0.3-alpha4#eadd97143a13d153d18a7b2ee2de3ff32a9494e8"
+dependencies = [
+ "hex",
+ "minicbor",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "pallas-configs"
-version = "1.0.0-alpha.1"
-source = "git+https://github.com/blockfrost/pallas.git?tag=blockfrost-platform-0.0.3-alpha2#fa233715b67b22fd8b191c9294858a3185e1207b"
+version = "1.0.0-alpha.2"
+source = "git+https://github.com/blockfrost/pallas.git?tag=blockfrost-platform-0.0.3-alpha4#eadd97143a13d153d18a7b2ee2de3ff32a9494e8"
 dependencies = [
  "base64 0.22.1",
  "num-rational",
- "pallas-addresses",
- "pallas-crypto",
- "pallas-primitives",
+ "pallas-addresses 1.0.0-alpha.2",
+ "pallas-crypto 1.0.0-alpha.2",
+ "pallas-primitives 1.0.0-alpha.2",
  "serde",
  "serde_json",
  "serde_with",
@@ -2733,7 +2758,20 @@ source = "git+https://github.com/blockfrost/pallas.git?tag=blockfrost-platform-0
 dependencies = [
  "cryptoxide",
  "hex",
- "pallas-codec",
+ "pallas-codec 1.0.0-alpha.1",
+ "rand_core 0.6.4",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "pallas-crypto"
+version = "1.0.0-alpha.2"
+source = "git+https://github.com/blockfrost/pallas.git?tag=blockfrost-platform-0.0.3-alpha4#eadd97143a13d153d18a7b2ee2de3ff32a9494e8"
+dependencies = [
+ "cryptoxide",
+ "hex",
+ "pallas-codec 1.0.0-alpha.2",
  "rand_core 0.6.4",
  "serde",
  "thiserror 1.0.69",
@@ -2746,11 +2784,31 @@ source = "git+https://github.com/blockfrost/pallas.git?tag=blockfrost-platform-0
 dependencies = [
  "binary-layout",
  "hex",
- "pallas-addresses",
- "pallas-codec",
- "pallas-crypto",
- "pallas-network",
- "pallas-traverse",
+ "pallas-addresses 1.0.0-alpha.1",
+ "pallas-codec 1.0.0-alpha.1",
+ "pallas-crypto 1.0.0-alpha.1",
+ "pallas-network 1.0.0-alpha.1",
+ "pallas-traverse 1.0.0-alpha.1",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "tap",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "pallas-hardano"
+version = "1.0.0-alpha.2"
+source = "git+https://github.com/blockfrost/pallas.git?tag=blockfrost-platform-0.0.3-alpha4#eadd97143a13d153d18a7b2ee2de3ff32a9494e8"
+dependencies = [
+ "binary-layout",
+ "hex",
+ "pallas-addresses 1.0.0-alpha.2",
+ "pallas-codec 1.0.0-alpha.2",
+ "pallas-crypto 1.0.0-alpha.2",
+ "pallas-network 1.0.0-alpha.2",
+ "pallas-traverse 1.0.0-alpha.2",
  "serde",
  "serde_json",
  "serde_with",
@@ -2767,8 +2825,25 @@ dependencies = [
  "byteorder",
  "hex",
  "itertools 0.13.0",
- "pallas-codec",
- "pallas-crypto",
+ "pallas-codec 1.0.0-alpha.1",
+ "pallas-crypto 1.0.0-alpha.1",
+ "rand 0.8.5",
+ "socket2",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "pallas-network"
+version = "1.0.0-alpha.2"
+source = "git+https://github.com/blockfrost/pallas.git?tag=blockfrost-platform-0.0.3-alpha4#eadd97143a13d153d18a7b2ee2de3ff32a9494e8"
+dependencies = [
+ "byteorder",
+ "hex",
+ "itertools 0.13.0",
+ "pallas-codec 1.0.0-alpha.2",
+ "pallas-crypto 1.0.0-alpha.2",
  "rand 0.8.5",
  "socket2",
  "thiserror 1.0.69",
@@ -2782,8 +2857,20 @@ version = "1.0.0-alpha.1"
 source = "git+https://github.com/blockfrost/pallas.git?tag=blockfrost-platform-0.0.3-alpha2#fa233715b67b22fd8b191c9294858a3185e1207b"
 dependencies = [
  "hex",
- "pallas-codec",
- "pallas-crypto",
+ "pallas-codec 1.0.0-alpha.1",
+ "pallas-crypto 1.0.0-alpha.1",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "pallas-primitives"
+version = "1.0.0-alpha.2"
+source = "git+https://github.com/blockfrost/pallas.git?tag=blockfrost-platform-0.0.3-alpha4#eadd97143a13d153d18a7b2ee2de3ff32a9494e8"
+dependencies = [
+ "hex",
+ "pallas-codec 1.0.0-alpha.2",
+ "pallas-crypto 1.0.0-alpha.2",
  "serde",
  "serde_json",
 ]
@@ -2795,10 +2882,26 @@ source = "git+https://github.com/blockfrost/pallas.git?tag=blockfrost-platform-0
 dependencies = [
  "hex",
  "itertools 0.13.0",
- "pallas-addresses",
- "pallas-codec",
- "pallas-crypto",
- "pallas-primitives",
+ "pallas-addresses 1.0.0-alpha.1",
+ "pallas-codec 1.0.0-alpha.1",
+ "pallas-crypto 1.0.0-alpha.1",
+ "pallas-primitives 1.0.0-alpha.1",
+ "paste",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "pallas-traverse"
+version = "1.0.0-alpha.2"
+source = "git+https://github.com/blockfrost/pallas.git?tag=blockfrost-platform-0.0.3-alpha4#eadd97143a13d153d18a7b2ee2de3ff32a9494e8"
+dependencies = [
+ "hex",
+ "itertools 0.13.0",
+ "pallas-addresses 1.0.0-alpha.2",
+ "pallas-codec 1.0.0-alpha.2",
+ "pallas-crypto 1.0.0-alpha.2",
+ "pallas-primitives 1.0.0-alpha.2",
  "paste",
  "serde",
  "thiserror 1.0.69",
@@ -2806,16 +2909,15 @@ dependencies = [
 
 [[package]]
 name = "pallas-txbuilder"
-version = "1.0.0-alpha.1"
-source = "git+https://github.com/blockfrost/pallas.git?tag=blockfrost-platform-0.0.3-alpha2#fa233715b67b22fd8b191c9294858a3185e1207b"
+version = "1.0.0-alpha.2"
+source = "git+https://github.com/blockfrost/pallas.git?tag=blockfrost-platform-0.0.3-alpha4#eadd97143a13d153d18a7b2ee2de3ff32a9494e8"
 dependencies = [
  "hex",
- "pallas-addresses",
- "pallas-codec",
- "pallas-crypto",
- "pallas-primitives",
- "pallas-traverse",
- "pallas-wallet",
+ "pallas-addresses 1.0.0-alpha.2",
+ "pallas-codec 1.0.0-alpha.2",
+ "pallas-crypto 1.0.0-alpha.2",
+ "pallas-primitives 1.0.0-alpha.2",
+ "pallas-traverse 1.0.0-alpha.2",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -2823,13 +2925,13 @@ dependencies = [
 
 [[package]]
 name = "pallas-utxorpc"
-version = "1.0.0-alpha.1"
-source = "git+https://github.com/blockfrost/pallas.git?tag=blockfrost-platform-0.0.3-alpha2#fa233715b67b22fd8b191c9294858a3185e1207b"
+version = "1.0.0-alpha.2"
+source = "git+https://github.com/blockfrost/pallas.git?tag=blockfrost-platform-0.0.3-alpha4#eadd97143a13d153d18a7b2ee2de3ff32a9494e8"
 dependencies = [
- "pallas-codec",
- "pallas-crypto",
- "pallas-primitives",
- "pallas-traverse",
+ "pallas-codec 1.0.0-alpha.2",
+ "pallas-crypto 1.0.0-alpha.2",
+ "pallas-primitives 1.0.0-alpha.2",
+ "pallas-traverse 1.0.0-alpha.2",
  "pallas-validate",
  "prost-types",
  "utxorpc-spec",
@@ -2837,34 +2939,20 @@ dependencies = [
 
 [[package]]
 name = "pallas-validate"
-version = "1.0.0-alpha.1"
-source = "git+https://github.com/blockfrost/pallas.git?tag=blockfrost-platform-0.0.3-alpha2#fa233715b67b22fd8b191c9294858a3185e1207b"
+version = "1.0.0-alpha.2"
+source = "git+https://github.com/blockfrost/pallas.git?tag=blockfrost-platform-0.0.3-alpha4#eadd97143a13d153d18a7b2ee2de3ff32a9494e8"
 dependencies = [
  "chrono",
  "hex",
  "itertools 0.14.0",
- "pallas-addresses",
- "pallas-codec",
- "pallas-crypto",
- "pallas-primitives",
- "pallas-traverse",
+ "pallas-addresses 1.0.0-alpha.2",
+ "pallas-codec 1.0.0-alpha.2",
+ "pallas-crypto 1.0.0-alpha.2",
+ "pallas-primitives 1.0.0-alpha.2",
+ "pallas-traverse 1.0.0-alpha.2",
  "serde",
  "thiserror 1.0.69",
  "tracing",
-]
-
-[[package]]
-name = "pallas-wallet"
-version = "1.0.0-alpha.1"
-source = "git+https://github.com/blockfrost/pallas.git?tag=blockfrost-platform-0.0.3-alpha2#fa233715b67b22fd8b191c9294858a3185e1207b"
-dependencies = [
- "bech32 0.9.1",
- "bip39",
- "cryptoxide",
- "ed25519-bip32",
- "pallas-crypto",
- "rand 0.8.5",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4765,9 +4853,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utxorpc-spec"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7148c5cd211c397a41245cfbd8d4cb8371d748ed5e3cf131ebcd9cacfa794206"
+checksum = "a1d984ee351b308377e118135e638a5d544fdb0855f12a3b088d9dcaf0432052"
 dependencies = [
  "bytes",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,14 +31,14 @@ toml = "0.8.23"
 thiserror = "2.0.12"
 sentry = "0.41.0"
 base64 = "0.22.1"
-pallas = { git = "https://github.com/blockfrost/pallas.git", tag = "blockfrost-platform-0.0.3-alpha2" }
-pallas-network = { git = "https://github.com/blockfrost/pallas.git", tag = "blockfrost-platform-0.0.3-alpha2" }
-pallas-crypto = { git = "https://github.com/blockfrost/pallas.git", tag = "blockfrost-platform-0.0.3-alpha2" }
-pallas-traverse = { git = "https://github.com/blockfrost/pallas.git", tag = "blockfrost-platform-0.0.3-alpha2" }
-pallas-codec = { git = "https://github.com/blockfrost/pallas.git", tag = "blockfrost-platform-0.0.3-alpha2" }
-pallas-addresses = { git = "https://github.com/blockfrost/pallas.git", tag = "blockfrost-platform-0.0.3-alpha2" }
-pallas-primitives = { git = "https://github.com/blockfrost/pallas.git", tag = "blockfrost-platform-0.0.3-alpha2" }
-pallas-hardano = { git = "https://github.com/blockfrost/pallas.git", tag = "blockfrost-platform-0.0.3-alpha2" }
+pallas = { git = "https://github.com/blockfrost/pallas.git", tag = "blockfrost-platform-0.0.3-alpha4" }
+pallas-network = { git = "https://github.com/blockfrost/pallas.git", tag = "blockfrost-platform-0.0.3-alpha4" }
+pallas-crypto = { git = "https://github.com/blockfrost/pallas.git", tag = "blockfrost-platform-0.0.3-alpha4" }
+pallas-traverse = { git = "https://github.com/blockfrost/pallas.git", tag = "blockfrost-platform-0.0.3-alpha4" }
+pallas-codec = { git = "https://github.com/blockfrost/pallas.git", tag = "blockfrost-platform-0.0.3-alpha4" }
+pallas-addresses = { git = "https://github.com/blockfrost/pallas.git", tag = "blockfrost-platform-0.0.3-alpha4" }
+pallas-primitives = { git = "https://github.com/blockfrost/pallas.git", tag = "blockfrost-platform-0.0.3-alpha4" }
+pallas-hardano = { git = "https://github.com/blockfrost/pallas.git", tag = "blockfrost-platform-0.0.3-alpha4" }
 reqwest = "0.12.12"
 hex = "0.4.3"
 metrics = { version = "0.24.1", default-features = false }

--- a/flake.lock
+++ b/flake.lock
@@ -103,16 +103,16 @@
     "dolos": {
       "flake": false,
       "locked": {
-        "lastModified": 1751915048,
-        "narHash": "sha256-GKSSOfxqx0TqW0RpB4+0Bv1J5jJRqYviQ3zrRbkBoy4=",
+        "lastModified": 1756144956,
+        "narHash": "sha256-uXKJA4nnVqC8SU7LOUSJm62GSOKcQdlvwgY+Ex1/KB8=",
         "owner": "txpipe",
         "repo": "dolos",
-        "rev": "42d955835d9c210af1f5ab270ca1d31182511bde",
+        "rev": "7996419d71eb7083fb74268a7f176b76ce9d63f2",
         "type": "github"
       },
       "original": {
         "owner": "txpipe",
-        "ref": "v0.26.0",
+        "ref": "v0.31.1",
         "repo": "dolos",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "advisory-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1750151065,
-        "narHash": "sha256-il+CAqChFIB82xP6bO43dWlUVs+NlG7a4g8liIP5HcI=",
+        "lastModified": 1756731353,
+        "narHash": "sha256-OylOWF5AASqDHsvZGiLCwBGI1wMvL4gaEMpAM88XqKY=",
         "owner": "rustsec",
         "repo": "advisory-db",
-        "rev": "7573f55ba337263f61167dbb0ea926cdc7c8eb5d",
+        "rev": "97dec1d752d5ce500b6db833350c13acd02b17cf",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
     flake-compat.flake = false;
     cardano-node.url = "github:IntersectMBO/cardano-node/10.4.1";
     cardano-node.flake = false; # otherwise, +2k dependencies we don’t really use
-    dolos.url = "github:txpipe/dolos/v0.26.0";
+    dolos.url = "github:txpipe/dolos/v0.31.1";
     dolos.flake = false;
     mithril.url = "github:input-output-hk/mithril/2524.0";
     testgen-hs.url = "github:input-output-hk/testgen-hs/10.4.1.1"; # make sure it follows cardano-node

--- a/nix/internal/darwin.nix
+++ b/nix/internal/darwin.nix
@@ -49,11 +49,18 @@ in
           mkdir -p $out/libexec
           mv $out/{${unix.packageName},lib} $out/libexec
           mkdir -p $out/bin
-          ( cd $out/bin ; ln -s ../libexec/${unix.packageName} ./ ; )
+
+          chmod -R +w $out
+          ${with pkgs; lib.getExe rsync} -a ${bundle-dolos}/. $out/libexec/.
+          chmod -R +w $out
+
+          ( cd $out/bin ; ln -s ../libexec/{${unix.packageName},dolos} ./ ; )
         '';
     });
 
     bundle-testgen-hs = nix-bundle-exe-lib-subdir (lib.getExe unix.testgen-hs);
+
+    bundle-dolos = nix-bundle-exe-lib-subdir "${unix.dolos}/bin/dolos";
 
     # Contents of the <https://github.com/blockfrost/homebrew-tap>
     # repo. We replace that workdir on each release.

--- a/nix/internal/darwin.nix
+++ b/nix/internal/darwin.nix
@@ -239,9 +239,9 @@ in
 
     make-dmg = {doSign ? false}: let
       outFileName = "${unix.package.pname}-${unix.package.version}-${inputs.self.shortRev or "dirty"}-${targetSystem}.dmg";
-      credentials = "/var/lib/buildkite-agent/signing.sh";
-      codeSigningConfig = "/var/lib/buildkite-agent/code-signing-config.json";
-      signingConfig = "/var/lib/buildkite-agent/signing-config.json";
+      credentials = "/var/lib/buildkite-agent-default/signing.sh";
+      codeSigningConfig = "/var/lib/buildkite-agent-default/code-signing-config.json";
+      signingConfig = "/var/lib/buildkite-agent-default/signing-config.json";
       packAndSign = pkgs.writeShellApplication {
         name = "pack-and-sign";
         runtimeInputs = with pkgs; [bash coreutils jq];
@@ -317,7 +317,7 @@ in
           ${
             if doSign
             then ''
-              # FIXME: this doesn’t work outside of `buildkite-agent`, it seems:
+              # FIXME: this doesn’t work outside of `buildkite-agent-default`, it seems:
               #(
               #  source ${credentials}
               #  security unlock-keychain -p "$SIGNING" "$signingKeyChain"
@@ -360,7 +360,7 @@ in
           ${
             if doSign
             then ''
-              exec sudo -u buildkite-agent \
+              exec sudo -u buildkite-agent-default \
                 "NOTARY_USER=''${NOTARY_USER:-}" \
                 "NOTARY_PASSWORD=''${NOTARY_PASSWORD:-}" \
                 "NOTARY_TEAM_ID=''${NOTARY_TEAM_ID:-}" \

--- a/nix/internal/linux.nix
+++ b/nix/internal/linux.nix
@@ -38,7 +38,17 @@ in
         buildCommand =
           drv.buildCommand
           + ''
-            ( cd $out ; ln -s bin/${unix.packageName} . ; )
+            chmod -R +w $out
+            ${with pkgs; lib.getExe rsync} -a ${bundle-dolos}/. $out/.
+            chmod -R +w $out
+            ( cd $out ; ln -s bin/{${unix.packageName},dolos} ./ ; )
           '';
       });
+
+    bundle-dolos = nix-bundle-exe {
+      inherit pkgs;
+      bin_dir = "bin";
+      exe_dir = "exe";
+      lib_dir = "lib";
+    } "${unix.dolos}/bin/dolos";
   }

--- a/nix/internal/windows.nix
+++ b/nix/internal/windows.nix
@@ -177,6 +177,7 @@ in rec {
   bundle = pkgs.runCommandNoCC "bundle" {} ''
     mkdir -p $out
     cp -r ${packageWithIcon}/. $out/.
+    cp -r ${dolos}/bin/. $out/.
   '';
 
   archive =

--- a/nix/internal/windows.nix
+++ b/nix/internal/windows.nix
@@ -216,6 +216,27 @@ in rec {
     stripRoot = false;
   };
 
+  dolos = craneLib.buildPackage {
+    src = inputs.dolos;
+    strictDeps = true;
+
+    CARGO_BUILD_TARGET = "x86_64-pc-windows-gnu";
+    TARGET_CC = "${pkgsCross.stdenv.cc}/bin/${pkgsCross.stdenv.cc.targetPrefix}cc";
+
+    TESTGEN_HS_PATH = "unused"; # Don’t try to download it in `build.rs`.
+
+    OPENSSL_DIR = "${pkgs.openssl.dev}";
+    OPENSSL_LIB_DIR = "${pkgs.openssl.out}/lib";
+    OPENSSL_INCLUDE_DIR = "${pkgs.openssl.dev}/include/";
+
+    depsBuildBuild = [
+      pkgsCross.stdenv.cc
+      pkgsCross.windows.pthreads
+    ];
+
+    doCheck = false; # we run Windows tests on real Windows on GHA
+  };
+
   packageWithIcon =
     pkgs.runCommand package.name {
       buildInputs = with pkgs; [


### PR DESCRIPTION
## Context

There were a few chores that needed doing:

* a6694ec chore: adjust macOS signing for the new signer machine setup
* e7ffda7 chore: add Dolos to archives and installers
* 99b84a0 chore: cross-compile Dolos from source for Windows
* ddeeac4 chore: update `inputs.advisory-db`
* fe65ef6 chore: update Pallas to the version that Dolos uses
* fe38bf6 chore: update Dolos to 0.31.1
