### PR TITLE
chore: update Dolos to 0.32.0 (the same as on GHA workers)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -119,16 +119,16 @@
     "dolos": {
       "flake": false,
       "locked": {
-        "lastModified": 1756144956,
-        "narHash": "sha256-uXKJA4nnVqC8SU7LOUSJm62GSOKcQdlvwgY+Ex1/KB8=",
+        "lastModified": 1756898941,
+        "narHash": "sha256-fQT5y5oXekJuCJ5Y3NUA0BmeUE/vv4+0dOwAf3j3no4=",
         "owner": "txpipe",
         "repo": "dolos",
-        "rev": "7996419d71eb7083fb74268a7f176b76ce9d63f2",
+        "rev": "16926bdca5d657643ce2ba3f1f2112f92a7261f8",
         "type": "github"
       },
       "original": {
         "owner": "txpipe",
-        "ref": "v0.31.1",
+        "ref": "v0.32.0",
         "repo": "dolos",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
     flake-compat.flake = false;
     cardano-node.url = "github:IntersectMBO/cardano-node/10.4.1";
     cardano-node.flake = false; # otherwise, +2k dependencies we don’t really use
-    dolos.url = "github:txpipe/dolos/v0.31.1";
+    dolos.url = "github:txpipe/dolos/v0.32.0";
     dolos.flake = false;
     blockfrost-tests.url = "github:blockfrost/blockfrost-tests";
     blockfrost-tests.flake = false;

--- a/nix/internal/unix.nix
+++ b/nix/internal/unix.nix
@@ -365,6 +365,7 @@ in
     dolos = craneLib.buildPackage (
       {
         src = inputs.dolos;
+        GIT_REVISION = inputs.dolos.rev;
         strictDeps = true;
         nativeBuildInputs =
           [pkgs.gnum4]

--- a/nix/internal/windows.nix
+++ b/nix/internal/windows.nix
@@ -219,6 +219,7 @@ in rec {
 
   dolos = craneLib.buildPackage {
     src = inputs.dolos;
+    GIT_REVISION = inputs.dolos.rev;
     strictDeps = true;
 
     CARGO_BUILD_TARGET = "x86_64-pc-windows-gnu";


### PR DESCRIPTION
## Context

Just a mini PR, like the title says.

I also set `GIT_REVISION` for the future, see:
* https://github.com/txpipe/dolos/pull/663