### PR TITLE
chore: update Dolos to `v1.0.0-beta.1`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       init-node:
         condition: service_completed_successfully
   dolos:
-    image: ghcr.io/txpipe/dolos:1.0.0-beta.0
+    image: ghcr.io/txpipe/dolos:1.0.0-beta.1
     entrypoint: /entrypoint.sh
     environment:
       NETWORK: $NETWORK

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - 3010:3010
     volumes:
       - ./docker/dolos-entrypoint.sh:/entrypoint.sh
-      - ./docker/dolos-config.toml.tpl:/config.toml
+      - ./docker/dolos-config.toml.tpl:/config.toml.tpl
       - dolos-db:/data
   blockfrost-platform:
     image: ghcr.io/blockfrost/blockfrost-platform:edge

--- a/flake.lock
+++ b/flake.lock
@@ -119,16 +119,16 @@
     "dolos": {
       "flake": false,
       "locked": {
-        "lastModified": 1757936472,
-        "narHash": "sha256-CPikHDJeAqjUxkvhvC64lyYcluy8j1UOsb7PJ2aLp9o=",
+        "lastModified": 1758146766,
+        "narHash": "sha256-pmsTtVEAQSg0KojzFvOqAYj0JXt6Bp9V9/pRCObIarw=",
         "owner": "txpipe",
         "repo": "dolos",
-        "rev": "0b6e4ec590f2b6f74909a801cb9f31a8aaeb4e4b",
+        "rev": "bb102d0907ae6cf127c4ba24cdee1e2cac16e2a2",
         "type": "github"
       },
       "original": {
         "owner": "txpipe",
-        "ref": "v1.0.0-beta.0",
+        "ref": "v1.0.0-beta.1",
         "repo": "dolos",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
     flake-compat.flake = false;
     cardano-node.url = "github:IntersectMBO/cardano-node/10.4.1";
     cardano-node.flake = false; # otherwise, +2k dependencies we don’t really use
-    dolos.url = "github:txpipe/dolos/v1.0.0-beta.0";
+    dolos.url = "github:txpipe/dolos/v1.0.0-beta.1";
     dolos.flake = false;
     blockfrost-tests.url = "github:blockfrost/blockfrost-tests";
     blockfrost-tests.flake = false;


### PR DESCRIPTION
## Context

`v1.0.0-beta.0` was unable to bootstrap successfully from Mithril ([Slack thread](https://input-output-rnd.slack.com/archives/C07UAU3PRFV/p1758100026991349)).