### PR TITLE
chore(release): 0.0.3-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## [0.0.3-rc.1] - 2025-09-18
 
 ### Removed
 
@@ -9,6 +9,9 @@
 - Set custom genesis config
 - Load balancing over a WebSocket (eliminating the need for public IP in the future)
 - Expose a `health_errors_total` gauge in metrics
+- More comprehensive error reporting under `GET /`
+- NixOS service (module)
+- Run original `blockfrost-tests` against the Platform
 
 #### New endpoints from Dolos
 
@@ -81,6 +84,9 @@
 ### Fixed
 
 - Trailing slash in `GET /{uuid}/` works again
+- Health reporting while still syncing in the Byron era
+- Native (not cross-compiled) `aarch64-linux` builds
+- Docs improvements
 
 ## [0.0.2] - 2025-03-20
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,7 +540,7 @@ dependencies = [
 
 [[package]]
 name = "blockfrost-platform"
-version = "0.0.2"
+version = "0.0.3-rc.1"
 dependencies = [
  "anyhow",
  "api-provider",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blockfrost-platform"
-version = "0.0.2"
+version = "0.0.3-rc.1"
 license = "Apache-2.0"
 edition = "2021"
 description = "The Blockfrost platform transforms your Cardano node infrastructure into a high-performance JSON API endpoint."


### PR DESCRIPTION
## Context

This is the commit that we’ll pre-release as `0.0.3-rc.1`: 21146cad1d796a3c38caadf20325fbc7c4302e68.

I have asked Core SREs to bump this to the front of the CI queue.

I haven’t changed the version of docs, because it's only a pre-release, and we haven’t updated them to mention Dolos (logged as #383) etc.