### PR TITLE
fix: support TLS in WebSockets (`wss://`)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4466,7 +4466,9 @@ checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
+ "native-tls",
  "tokio",
+ "tokio-native-tls",
  "tungstenite",
 ]
 
@@ -4696,6 +4698,7 @@ dependencies = [
  "http 1.3.1",
  "httparse",
  "log",
+ "native-tls",
  "rand 0.9.0",
  "sha1",
  "thiserror 2.0.12",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ axum = { version = "0.8.2", features = ["ws"] }
 tokio = { version = "1.43.0", features = ["rt", "rt-multi-thread", "signal"] }
 futures = "0.3"
 futures-util = "0.3"
-tungstenite = "0.26"
-tokio-tungstenite = "0.26"
+tungstenite = { version = "0.26", features = ["native-tls"] }
+tokio-tungstenite = { version = "0.26", features = ["native-tls"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter", "fmt"] }
 serde = { version = "1.0.219", features = ["derive"] }


### PR DESCRIPTION
## Context

I missed that this HTTP library needs additional flags to enable HTTPS… for `wss://`…

You can test it with this patch locally to skip the port check:

```diff
diff --git a/src/icebreakers/api.rs b/src/icebreakers/api.rs
index 1e08cbf..3ed62a5 100644
--- a/src/icebreakers/api.rs
+++ b/src/icebreakers/api.rs
@@ -107,6 +107,7 @@ impl IcebreakersAPI {
         let response = self
             .client
             .post(&url)
+            .header("X-SKIP-PORT-CHECK", "1")
             .json(&body)
             .send()
             .await
```