### PR TITLE
chore: don’t push the `latest` OCI tag for pre-releases

### DIFF
--- a/.github/workflows/oci-image.yaml
+++ b/.github/workflows/oci-image.yaml
@@ -26,12 +26,16 @@ jobs:
         run: |
           image=ghcr.io/blockfrost/blockfrost-platform
           docker push $image:edge
-      - name: 📤 Push the image (release, latest)
+      - name: 📤 Push the image (version tag)
         if: github.event_name == 'release' && github.event.action == 'published'
         run: |
           image=ghcr.io/blockfrost/blockfrost-platform
           docker push $image:edge
           docker tag  $image:edge $image:${{ github.event.release.tag_name }}
-          docker tag  $image:edge $image:latest
           docker push $image:${{ github.event.release.tag_name }}
+      - name: 📤 Push the image (latest tag)
+        if: github.event_name == 'release' && github.event.action == 'published' && !github.event.release.prerelease
+        run: |
+          image=ghcr.io/blockfrost/blockfrost-platform
+          docker tag  $image:edge $image:latest
           docker push $image:latest


### PR DESCRIPTION
## Context

I noticed that the [`latest` tag points to `0.0.3-rc.3`](https://github.com/blockfrost/blockfrost-platform/pkgs/container/blockfrost-platform), which is a pre-release (release candidate):

<img width="50%" src="https://github.com/user-attachments/assets/879860ea-57ec-4228-a0d0-3777a738bb7c" />


Let’s keep it at the latest stable non-RC release?

If we agree, I'll force-push `latest` back to `0.0.2`.