### PR TITLE
chore: add Acropolis to the devshell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,15 @@
     "acropolis": {
       "flake": false,
       "locked": {
-        "lastModified": 1761050893,
-        "narHash": "sha256-BjBuRlwnnMIglHhxz3AodobEU6h6lrGIaWeH4XKYycQ=",
+        "lastModified": 1761154810,
+        "narHash": "sha256-dVe6QLB2+EnkzTrubvQA9p7zxaUVUQI29CVZoaABSI8=",
         "owner": "input-output-hk",
         "repo": "acropolis",
-        "rev": "976793e75c47334176f83ad6f4fa7e6213c6ccbb",
+        "rev": "371aa46d74af8ea21cf076ed699d921dc827639b",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "pull/254/head",
         "repo": "acropolis",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
     cardano-node.flake = false; # otherwise, +2k dependencies we don’t really use
     dolos.url = "github:txpipe/dolos/v1.0.0-beta.5";
     dolos.flake = false;
-    acropolis.url = "github:input-output-hk/acropolis/pull/254/head";
+    acropolis.url = "github:input-output-hk/acropolis";
     acropolis.flake = false;
     blockfrost-tests.url = "github:blockfrost/blockfrost-tests";
     blockfrost-tests.flake = false;

--- a/nix/devshells.nix
+++ b/nix/devshells.nix
@@ -33,8 +33,8 @@ in {
     }
     {package = internal.mithril-client;}
     {package = internal.dolos;}
-    {package = internal.acropolis.acropolis_process_omnibus;}
-    {package = internal.acropolis.acropolis_process_replayer;}
+    {package = internal.acropolis-process-omnibus;}
+    {package = internal.acropolis-process-replayer;}
     {package = pkgs.cargo-nextest;}
     {package = pkgs.cargo-tarpaulin;}
     {


### PR DESCRIPTION
Resolves https://github.com/blockfrost/blockfrost-ops/issues/2023

## Context

In:
* https://github.com/blockfrost/blockfrost-ops/issues/2023

So far it's a derivation in our repo. But ops can already use it, if needed.

### Upstream PRs

To make it work nicely, I had to make some changes upstream:
* https://github.com/input-output-hk/acropolis/pull/254

I have also contributed a `flake.nix` upstream:
* https://github.com/input-output-hk/acropolis/pull/266