### PR TITLE
chore: add more timeouts to CI workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,8 +62,8 @@ jobs:
         run: cargo build --workspace --release --verbose
 
       - name: Test
-        run: cargo test --workspace --lib --verbose
         timeout-minutes: 10
+        run: cargo test --workspace --lib --verbose
 
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -93,6 +93,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Integration Tests
+        timeout-minutes: 10
         run: nix develop .# --command cargo test --verbose --test endpoints_test
 
   blockfrost_integration_tests:
@@ -108,22 +109,26 @@ jobs:
             cardano_node_socket_path: /run/cardano-node/node.socket
             project_id_secret: BLOCKFROST_PREVIEW_PROJECT_ID
             submit_mnemonic_secret: BLOCKFROST_PREVIEW_SUBMIT_MNEMONIC
+            timeout_minutes: 5
           - network: preprod
             dolos_endpoint: http://127.0.0.1:3009
             cardano_node_socket_path: /run/cardano-node/node_preprod.socket
             project_id_secret: BLOCKFROST_PREPROD_PROJECT_ID
             submit_mnemonic_secret: BLOCKFROST_PREPROD_SUBMIT_MNEMONIC
+            timeout_minutes: 5
           - network: mainnet
             dolos_endpoint: http://127.0.0.1:3008
             cardano_node_socket_path: /run/cardano-node/node_mainnet.socket
             project_id_secret: BLOCKFROST_MAINNET_PROJECT_ID
             submit_mnemonic_secret: BLOCKFROST_MAINNET_SUBMIT_MNEMONIC
+            timeout_minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Run Blockfrost Tests
         continue-on-error: true
+        timeout-minutes: ${{ fromJSON(matrix.timeout_minutes) }}
         env:
           PROJECT_ID: ${{ secrets[matrix.project_id_secret] }}
           SUBMIT_MNEMONIC: ${{ secrets[matrix.submit_mnemonic_secret] }}
@@ -140,6 +145,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Hydra Tests
+        timeout-minutes: 15
         env:
           CARDANO_NODE_SOCKET_PATH: /run/cardano-node/node.socket
           BLOCKFROST_PROJECT_ID: ${{ secrets.BLOCKFROST_TESTS_PROJECT_ID }}
@@ -162,6 +168,7 @@ jobs:
         run: cargo install cargo-tarpaulin
 
       - name: Generate coverage report
+        timeout-minutes: 10
         run: cargo tarpaulin --workspace --all --lib --features tarpaulin --out html --output-dir coverage --fail-under 11
 
       - name: Upload coverage report for GitHub Pages


### PR DESCRIPTION
## Context

See this recent 3-hour run for a justification: [/actions/runs/21036058260/job/60484117987](https://github.com/blockfrost/blockfrost-platform/actions/runs/21036058260/job/60484117987?pr=431).

If these jobs take more, it’s definitely an erroneous run.