### PR TITLE
fix(oci): prevent the `unknown/unknown` architecture in the GitHub UI

### DIFF
--- a/.github/workflows/oci-image.yaml
+++ b/.github/workflows/oci-image.yaml
@@ -52,6 +52,9 @@ jobs:
             GIT_REVISION=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          # Prevent the `unknown/unknown` architecture in the GitHub UI:
+          provenance: false
+          sbom: false
 
   merge:
     name: Create multi-arch manifests


### PR DESCRIPTION
## Context

Follow-up to:
* #433

… which [_almost_ worked](https://github.com/blockfrost/blockfrost-platform/actions/runs/21136064427/job/60778990424).

The multi-arch images are there, but also some extra `unknown/unknown` architecture for `attestation-manifest`s:

```
❯ docker buildx imagetools inspect --raw ghcr.io/blockfrost/blockfrost-platform:8cb2ffcb5d5e73a5a1153bed63d967d4934edabb
```
```json
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.index.v1+json",
  "manifests": [
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:7f7a340a426746b300b9dbfc0a793d86aa89b76e644e84cb62ded96bced6c9e8",
      "size": 3514,
      "platform": {
        "architecture": "amd64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:9f267aec8523cc19cee4e32bbac4c3151c60cf006329ca1124f28eb70a631013",
      "size": 567,
      "annotations": {
        "vnd.docker.reference.digest": "sha256:7f7a340a426746b300b9dbfc0a793d86aa89b76e644e84cb62ded96bced6c9e8",
        "vnd.docker.reference.type": "attestation-manifest"
      },
      "platform": {
        "architecture": "unknown",
        "os": "unknown"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:7a86c73e9aac6b88e5c9910c3d4a51591f3130835b060f85c041e16696b0402a",
      "size": 3514,
      "platform": {
        "architecture": "arm64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:188332b86d4afdc880ceb7ee744442f376304e7699986ee15e3e22e013744b62",
      "size": 567,
      "annotations": {
        "vnd.docker.reference.digest": "sha256:7a86c73e9aac6b88e5c9910c3d4a51591f3130835b060f85c041e16696b0402a",
        "vnd.docker.reference.type": "attestation-manifest"
      },
      "platform": {
        "architecture": "unknown",
        "os": "unknown"
      }
    }
  ]
```

See here for an example:
* <https://github.com/blockfrost/blockfrost-platform/pkgs/container/blockfrost-platform/647969698?tag=8cb2ffcb5d5e73a5a1153bed63d967d4934edabb>