### PR TITLE
fix: align `glibc` versions in the `Dockerfile`

### DIFF
--- a/.github/workflows/oci-image.yaml
+++ b/.github/workflows/oci-image.yaml
@@ -62,7 +62,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          docker run --rm "${{ env.IMAGE }}:${{ github.sha }}-${{ matrix.arch }}" -- --version
+          docker run --rm "${{ env.IMAGE }}:${{ github.sha }}-${{ matrix.arch }}" --version
 
   merge:
     name: Create multi-arch manifests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lukemathwalker/cargo-chef:latest-rust-1 AS base
+FROM lukemathwalker/cargo-chef:latest-rust-1-trixie AS base
 
 # hadolint ignore=DL3008
 RUN apt-get update \
@@ -34,7 +34,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
   --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
   cargo build --release
 
-FROM gcr.io/distroless/cc-debian12:dca9008b864a381b5ce97196a4d8399ac3c2fa65 AS runtime
+FROM gcr.io/distroless/cc-debian13@sha256:05d26fe67a875592cd65f26b2bcfadb8830eae53e68945784e39b23e62c382e0 AS runtime
 COPY --from=builder /app/target/release/blockfrost-platform /app/
 
 ARG GIT_REVISION

--- a/nix/devshells.nix
+++ b/nix/devshells.nix
@@ -128,6 +128,7 @@ in {
       [
         pkgs.unixtools.xxd
         internal.rustPackages.clippy
+        pkgs.hadolint
         pkgs.websocat
       ]
       ++ lib.optionals pkgs.stdenv.isLinux [


### PR DESCRIPTION
Resolves #439

## Context

The `glibc` version in our build stage doesn’t match the one in runtime.

More in:
* #439

## Testing

🐞 You can see that the bug was reproduced here – [/actions/runs/21390449758/job/61575793683](https://github.com/blockfrost/blockfrost-platform/actions/runs/21390449758/job/61575793683):

```
❯ docker run --rm "ghcr.io/blockfrost/blockfrost-platform:0f0a3adc506cb89704d5b1dbadc7e20b5d7a02fc-amd64" -- --version
/app/blockfrost-platform: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by /app/blockfrost-platform)
```

✅ And fixed here – [/actions/runs/21391605249/job/61579615465](https://github.com/blockfrost/blockfrost-platform/actions/runs/21391605249/job/61579615465?pr=440#step:6:8):

```
❯ docker run --rm "ghcr.io/blockfrost/blockfrost-platform:9bd6211a070bc4f3bd905334356f1799713c736c-amd64" --version
blockfrost-platform 0.0.3-rc.3 (9bd6211a070bc4f3bd905334356f1799713c736c)
```