### PR TITLE
chore(fmt): add `yamllint`

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,6 @@
+extends: default
+rules:
+  document-start: disable
+  line-length:
+    max: 160
+  truthy: disable

--- a/flake.lock
+++ b/flake.lock
@@ -476,11 +476,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750931469,
-        "narHash": "sha256-0IEdQB1nS+uViQw4k3VGUXntjkDp7aAlqcxdewb/hAc=",
+        "lastModified": 1770228511,
+        "narHash": "sha256-wQ6NJSuFqAEmIg2VMnLdCnUc0b7vslUohqqGGD+Fyxk=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "ac8e6f32e11e9c7f153823abc3ab007f2a65d3e1",
+        "rev": "337a4fe074be1042a35086f15481d763b8ddc0e7",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -113,6 +113,7 @@
             shfmt.enable = true;
             taplo.enable = true; # TOML
             yamlfmt.enable = pkgs.system != "x86_64-darwin"; # a treefmt-nix+yamlfmt bug on Intel Macs
+            yamllint.enable = true;
           };
           settings.global.excludes = [
             "**/.eslintignore"


### PR DESCRIPTION
## Context

My editor uses `yamllint`, and it's regularly tripping on our `.github/workflows/ci.yaml`.

So let’s configure some shared `yamllint` settings that work well with GitHub Workflow YAMLs.