### PR TITLE
chore: un-ignore test_route_submit_error test

### DIFF
--- a/crates/platform/tests/submit_test.rs
+++ b/crates/platform/tests/submit_test.rs
@@ -47,8 +47,6 @@ mod tests {
         assert_eq!(expected, &local_body_str);
     }
 
-    // FIXME: unignore this test after <https://github.com/blockfrost/blockfrost-platform/issues/459>.
-    #[ignore]
     // Test: `/tx/submit` error has same response as blockfrost API
     #[tokio::test]
     #[ntest::timeout(120_000)]


### PR DESCRIPTION
Since Cardano node version is upgraded on environments, this test should be safe to un-ignore.