### PR TITLE
fix(hydra,tests): retry when returning funds to `SUBMIT_MNEMONIC`

### DIFF
--- a/nix/internal/hydra-blockfrost-test.sh
+++ b/nix/internal/hydra-blockfrost-test.sh
@@ -584,27 +584,40 @@ mkdir -p $txdir
 
 declare -A lovelace_remaining
 
+max_return_attempts=5
+return_retry_delay=25
+
 for participant in alice-funds bob-funds alice-node bob-node; do
-  log info "Returning funds from $participant to ‘SUBMIT_MNEMONIC’"
+  for return_attempt in $(seq 1 $max_return_attempts); do
+    log info "Returning funds from $participant to 'SUBMIT_MNEMONIC'"
 
-  cardano-cli query utxo \
-    --address "$(cat credentials/"$participant"/payment.addr)" \
-    --out-file $txdir/utxo-"$participant".json
+    cardano-cli query utxo \
+      --address "$(cat credentials/"$participant"/payment.addr)" \
+      --out-file $txdir/utxo-"$participant".json
 
-  lovelace_remaining["$participant"]=$(jq '[.[] | .value.lovelace] | add // 0' $txdir/utxo-"$participant".json)
+    lovelace_remaining["$participant"]=$(jq '[.[] | .value.lovelace] | add // 0' $txdir/utxo-"$participant".json)
 
-  # shellcheck disable=SC2046
-  cardano-cli latest transaction build \
-    $(jq <$txdir/utxo-"$participant".json -j 'to_entries[].key | "--tx-in ", ., " "') \
-    --change-address "$(cat credentials/submit-mnemonic/payment.addr)" \
-    --out-file $txdir/tx-"$participant".json
+    # shellcheck disable=SC2046
+    if cardano-cli latest transaction build \
+      $(jq <$txdir/utxo-"$participant".json -j 'to_entries[].key | "--tx-in ", ., " "') \
+      --change-address "$(cat credentials/submit-mnemonic/payment.addr)" \
+      --out-file $txdir/tx-"$participant".json &&
+      cardano-cli latest transaction sign \
+        --tx-file $txdir/tx-"$participant".json \
+        --signing-key-file credentials/"$participant"/payment.sk \
+        --out-file $txdir/tx-signed-"$participant".json &&
+      cardano-cli latest transaction submit --tx-file $txdir/tx-signed-"$participant".json; then
+      break
+    fi
 
-  cardano-cli latest transaction sign \
-    --tx-file $txdir/tx-"$participant".json \
-    --signing-key-file credentials/"$participant"/payment.sk \
-    --out-file $txdir/tx-signed-"$participant".json
+    if ((return_attempt == max_return_attempts)); then
+      log fatal "All $max_return_attempts attempts to return funds from $participant failed."
+      exit 1
+    fi
 
-  cardano-cli latest transaction submit --tx-file $txdir/tx-signed-"$participant".json
+    log warn "Return attempt $return_attempt for $participant failed, retrying in ${return_retry_delay}s (waiting for a new block)…"
+    sleep "$return_retry_delay"
+  done
 done
 
 # ---------------------------------------------------------------------------- #

--- a/nix/internal/hydra-bridge-gateway-test.sh
+++ b/nix/internal/hydra-bridge-gateway-test.sh
@@ -609,31 +609,46 @@ change_address=$(cat credentials/submit-mnemonic/payment.addr)
 
 declare -A lovelace_remaining
 
+max_return_attempts=5
+return_retry_delay=25
+
 for participant in bridge-hydra gateway-hydra; do
-  addr=$(cat credentials/"$participant"/payment.addr)
-  utxo_json=$(cardano-cli query utxo --address "$addr" --out-file /dev/stdout)
-  funds=$(echo "$utxo_json" | jq '[.[] | .value.lovelace] | add // 0')
-  lovelace_remaining["$participant"]=$funds
-  log info "Returning funds from $participant ($funds lovelace)…"
+  for return_attempt in $(seq 1 $max_return_attempts); do
+    addr=$(cat credentials/"$participant"/payment.addr)
+    utxo_json=$(cardano-cli query utxo --address "$addr" --out-file /dev/stdout)
+    funds=$(echo "$utxo_json" | jq '[.[] | .value.lovelace] | add // 0')
+    lovelace_remaining["$participant"]=$funds
+    log info "Returning funds from $participant ($funds lovelace)…"
 
-  if ((funds == 0)); then
-    log warn "$participant has no funds to return; skipping."
-    continue
-  fi
+    if ((funds == 0)); then
+      log warn "$participant has no funds to return; skipping."
+      break
+    fi
 
-  tx_ins=$(echo "$utxo_json" | jq -j 'to_entries[].key | "--tx-in ", ., " "')
+    tx_ins=$(echo "$utxo_json" | jq -j 'to_entries[].key | "--tx-in ", ., " "')
 
-  # shellcheck disable=SC2086
-  cardano-cli latest transaction build \
-    $tx_ins \
-    --change-address "$change_address" \
-    --out-file "$txdir/tx-$participant.json"
-  cardano-cli latest transaction sign \
-    --tx-file "$txdir/tx-$participant.json" \
-    --signing-key-file "credentials/$participant/payment.sk" \
-    --out-file "$txdir/tx-signed-$participant.json"
-  cardano-cli latest transaction submit --tx-file "$txdir/tx-signed-$participant.json"
-  log info "Returned funds from $participant."
+    # shellcheck disable=SC2086
+    if cardano-cli latest transaction build \
+      $tx_ins \
+      --change-address "$change_address" \
+      --out-file "$txdir/tx-$participant.json" &&
+      cardano-cli latest transaction sign \
+        --tx-file "$txdir/tx-$participant.json" \
+        --signing-key-file "credentials/$participant/payment.sk" \
+        --out-file "$txdir/tx-signed-$participant.json" &&
+      cardano-cli latest transaction submit --tx-file "$txdir/tx-signed-$participant.json"; then
+      log info "Returned funds from $participant."
+      break
+    fi
+
+    if ((return_attempt == max_return_attempts)); then
+      log fatal "All $max_return_attempts attempts to return funds from $participant failed."
+      exit 1
+    fi
+
+    log warn "Return attempt $return_attempt for $participant failed, retrying in ${return_retry_delay}s (waiting for a new block)…"
+    sleep "$return_retry_delay"
+  done
 done
 
 # ---------------------------------------------------------------------------- #

--- a/nix/internal/hydra-platform-gateway-test.sh
+++ b/nix/internal/hydra-platform-gateway-test.sh
@@ -577,31 +577,46 @@ change_address=$(cat credentials/submit-mnemonic/payment.addr)
 
 declare -A lovelace_remaining
 
+max_return_attempts=5
+return_retry_delay=25
+
 for participant in gateway-hydra platform-hydra platform-reward; do
-  addr=$(cat credentials/"$participant"/payment.addr)
-  utxo_json=$(cardano-cli query utxo --address "$addr" --out-file /dev/stdout)
-  funds=$(echo "$utxo_json" | jq '[.[] | .value.lovelace] | add // 0')
-  lovelace_remaining["$participant"]=$funds
-  log info "Returning funds from $participant ($funds lovelace)…"
+  for return_attempt in $(seq 1 $max_return_attempts); do
+    addr=$(cat credentials/"$participant"/payment.addr)
+    utxo_json=$(cardano-cli query utxo --address "$addr" --out-file /dev/stdout)
+    funds=$(echo "$utxo_json" | jq '[.[] | .value.lovelace] | add // 0')
+    lovelace_remaining["$participant"]=$funds
+    log info "Returning funds from $participant ($funds lovelace)…"
 
-  if ((funds == 0)); then
-    log warn "$participant has no funds to return; skipping."
-    continue
-  fi
+    if ((funds == 0)); then
+      log warn "$participant has no funds to return; skipping."
+      break
+    fi
 
-  tx_ins=$(echo "$utxo_json" | jq -j 'to_entries[].key | "--tx-in ", ., " "')
+    tx_ins=$(echo "$utxo_json" | jq -j 'to_entries[].key | "--tx-in ", ., " "')
 
-  # shellcheck disable=SC2086
-  cardano-cli latest transaction build \
-    $tx_ins \
-    --change-address "$change_address" \
-    --out-file "$txdir/tx-$participant.json"
-  cardano-cli latest transaction sign \
-    --tx-file "$txdir/tx-$participant.json" \
-    --signing-key-file "credentials/$participant/payment.sk" \
-    --out-file "$txdir/tx-signed-$participant.json"
-  cardano-cli latest transaction submit --tx-file "$txdir/tx-signed-$participant.json"
-  log info "Returned funds from $participant."
+    # shellcheck disable=SC2086
+    if cardano-cli latest transaction build \
+      $tx_ins \
+      --change-address "$change_address" \
+      --out-file "$txdir/tx-$participant.json" &&
+      cardano-cli latest transaction sign \
+        --tx-file "$txdir/tx-$participant.json" \
+        --signing-key-file "credentials/$participant/payment.sk" \
+        --out-file "$txdir/tx-signed-$participant.json" &&
+      cardano-cli latest transaction submit --tx-file "$txdir/tx-signed-$participant.json"; then
+      log info "Returned funds from $participant."
+      break
+    fi
+
+    if ((return_attempt == max_return_attempts)); then
+      log fatal "All $max_return_attempts attempts to return funds from $participant failed."
+      exit 1
+    fi
+
+    log warn "Return attempt $return_attempt for $participant failed, retrying in ${return_retry_delay}s (waiting for a new block)…"
+    sleep "$return_retry_delay"
+  done
 done
 
 # ---------------------------------------------------------------------------- #


### PR DESCRIPTION
## Context

We already retry when funding – let's do the same when returning.

Fixes failures like:
- https://github.com/blockfrost/blockfrost-platform/actions/runs/24184666333/job/70602225315

```
test:    2026-04-09T13:33:03.049684Z  INFO All 3 fanout cycles completed successfully!
test:    2026-04-09T13:33:03.051833Z  INFO Stopping Gateway (pid 432220) and SDK Bridge (pid 432265)…
test:    2026-04-09T13:33:03.062196Z  INFO Gateway and SDK Bridge stopped.
test:    2026-04-09T13:33:03.064438Z  INFO Waiting 30s for in-flight L1 transactions to clear the mempool…
test:    2026-04-09T13:33:33.068901Z  INFO Verifying that funds were transferred on L1 to the Gateway…
test:    2026-04-09T13:33:39.159544Z  INFO Gateway address has 48.492048 ADA (48492048 lovelace), expected at least 18.000000 ADA (18000000 lovelace)
test:    2026-04-09T13:33:39.162220Z  INFO … OK, L1 fund transfer verified! Gateway has at least 18.000000 ADA.
test:    2026-04-09T13:33:39.164316Z  INFO Returning all funds to 'SUBMIT_MNEMONIC'…
test:    2026-04-09T13:33:45.176938Z  INFO Returning funds from bridge-hydra (57624341 lovelace)…
Estimated transaction fee: 169681 Lovelace
Transaction successfully submitted. Transaction hash is:
{"txhash":"635fe8926ceab5857c8961f77eb53ca40b31d5f71f38a2acd2580208e77c8767"}
test:    2026-04-09T13:33:45.439945Z  INFO Returned funds from bridge-hydra.
test:    2026-04-09T13:33:51.540239Z  INFO Returning funds from gateway-hydra (48492048 lovelace)…
Estimated transaction fee: 223933 Lovelace
Command failed: transaction submit
Error: Error while submitting tx: ShelleyTxValidationError ShelleyBasedEraConway (ApplyTxError (ConwayUtxowFailure (UtxoFailure (BadInputsUTxO (fromList [TxIn (TxId {unTxId = SafeHash "37672031c2598048c3a4c86ecedf2b1f01fc4e44f9503b6331f3dd2ee728258a"}) (TxIx {unTxIx = 4})]))) :| [ConwayUtxowFailure (UtxoFailure (ValueNotConservedUTxO (Mismatch {mismatchSupplied = MaryValue (Coin 18000000) (MultiAsset (fromList [])), mismatchExpected = MaryValue (Coin 48492048) (MultiAsset (fromList []))})))]))
CallStack (from HasCallStack):
  fromExceptTCli, called at src/Cardano/CLI/EraBased/Transaction/Run.hs:108:36 in cardano-cli-10.15.0.0-8Wt5zqMzGK01hIiOGrx5Dd:Cardano.CLI.EraBased.Transaction.Run
  runTransactionCmds, called at src/Cardano/CLI/EraBased/Run.hs:61:5 in cardano-cli-10.15.0.0-8Wt5zqMzGK01hIiOGrx5Dd:Cardano.CLI.EraBased.Run
  runCmds, called at src/Cardano/CLI/EraBased/Run.hs:35:35 in cardano-cli-10.15.0.0-8Wt5zqMzGK01hIiOGrx5Dd:Cardano.CLI.EraBased.Run
  runAnyEraCommand, called at src/Cardano/CLI/Run.hs:56:5 in cardano-cli-10.15.0.0-8Wt5zqMzGK01hIiOGrx5Dd:Cardano.CLI.Run
  runClientCommand, called at app/cardano-cli.hs:58:14 in cardano-cli-10.15.0.0-ELZllK78iuB9WSopnNsM4Q-cardano-cli:Main

=== Test FAILED ===
Error: Process completed with exit code 1.
```