### PR TITLE
Fix and check all installers before the pre-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,11 @@ jobs:
           $nixdl  result-installer-x86_64-darwin   "$ref"#internal.x86_64-darwin.installer
           $nixdl  result-installer-aarch64-darwin  "$ref"#internal.aarch64-darwin.installer
 
+          $nixdl  result-archive-bridge-x86_64-linux      "$ref"#internal.x86_64-linux.archive-bridge
+          $nixdl  result-archive-bridge-aarch64-linux     "$ref"#internal.aarch64-linux.archive-bridge
+          $nixdl  result-archive-bridge-x86_64-darwin     "$ref"#internal.x86_64-darwin.archive-bridge
+          $nixdl  result-archive-bridge-aarch64-darwin    "$ref"#internal.aarch64-darwin.archive-bridge
+
           $nixdl  result-homebrew-tap              "$ref"#internal.aarch64-darwin.homebrew-tap
           $nixdl  result-curl-bash-install         "$ref"#internal.x86_64-linux.curl-bash-install
 
@@ -62,6 +67,10 @@ jobs:
             result-installer-x86_64-windows/*.exe
             result-installer-x86_64-darwin/*.dmg
             result-installer-aarch64-darwin/*.dmg
+            result-archive-bridge-x86_64-linux/*.tar.bz2
+            result-archive-bridge-aarch64-linux/*.tar.bz2
+            result-archive-bridge-x86_64-darwin/*.tar.bz2
+            result-archive-bridge-aarch64-darwin/*.tar.bz2
             result-curl-bash-install/*.sh
 
       - name: Update the Homebrew tap

--- a/crates/common/src/cardano_keys.rs
+++ b/crates/common/src/cardano_keys.rs
@@ -7,7 +7,7 @@
 //! - `transaction sign`
 //! - Reading/writing cardano-cli JSON envelope format
 
-use anyhow::{Result, anyhow, bail};
+use anyhow::{Context, Result, anyhow, bail};
 use cardano_serialization_lib::{
     Address, Credential, EnterpriseAddress, FixedTransaction, NetworkId, PrivateKey, PublicKey,
 };
@@ -19,8 +19,10 @@ const CBOR_32_PREFIX: &str = "5820";
 /// Read a cardano-cli signing-key JSON envelope and return the raw 32-byte
 /// ed25519 private key.
 pub fn read_skey_bytes(skey_path: &Path) -> Result<[u8; 32]> {
-    let contents = std::fs::read_to_string(skey_path)?;
-    let envelope: serde_json::Value = serde_json::from_str(&contents)?;
+    let contents = std::fs::read_to_string(skey_path)
+        .with_context(|| format!("failed to read signing key from {}", skey_path.display()))?;
+    let envelope: serde_json::Value = serde_json::from_str(&contents)
+        .with_context(|| format!("invalid JSON in signing key {}", skey_path.display()))?;
     parse_skey_envelope(&envelope)
 }
 

--- a/crates/common/src/types.rs
+++ b/crates/common/src/types.rs
@@ -29,6 +29,14 @@ impl Network {
             Self::Custom => "custom",
         }
     }
+
+    /// Default public Gateway URL for this network.
+    pub fn default_gateway_url(&self) -> &'static str {
+        match self {
+            Self::Preprod | Self::Preview => "https://api-dev.icebreakers.blockfrost.io",
+            Self::Mainnet | Self::Custom => "https://icebreakers-api.blockfrost.io",
+        }
+    }
 }
 
 #[derive(Debug, Clone, ValueEnum, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/gateway/config/development.toml
+++ b/crates/gateway/config/development.toml
@@ -21,7 +21,6 @@ microtransactions_per_fanout = 2
 [hydra_bridge]
 max_concurrent_hydra_nodes = 2
 cardano_signing_key = "./hydra-config/preview/_our-keys/payment/payment.sk"
-node_socket_path = "/run/cardano-node/node.socket"
 commit_ada = 4.0
 lovelace_per_request = 100_000
 requests_per_microtransaction = 10

--- a/crates/platform/src/icebreakers/api.rs
+++ b/crates/platform/src/icebreakers/api.rs
@@ -1,5 +1,5 @@
 use crate::{load_balancer::LoadBalancerConfig, server::state::ApiPrefix};
-use bf_common::{config::Config, errors::AppError, types::Network};
+use bf_common::{config::Config, errors::AppError};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -48,17 +48,10 @@ impl IcebreakersAPI {
     ) -> Result<Option<Arc<Self>>, AppError> {
         match &config.icebreakers_config {
             Some(icebreakers_config) => {
-                let api_url = icebreakers_config.gateway_url.clone().unwrap_or_else(|| {
-                    match config.network {
-                        Network::Preprod | Network::Preview => {
-                            "https://api-dev.icebreakers.blockfrost.io"
-                        },
-                        Network::Mainnet | Network::Custom => {
-                            "https://icebreakers-api.blockfrost.io"
-                        },
-                    }
-                    .to_string()
-                });
+                let api_url = icebreakers_config
+                    .gateway_url
+                    .clone()
+                    .unwrap_or_else(|| config.network.default_gateway_url().to_string());
 
                 let client = Client::builder()
                     .local_address(config.server_address)

--- a/crates/sdk_bridge/src/config.rs
+++ b/crates/sdk_bridge/src/config.rs
@@ -8,11 +8,10 @@ use url::Url;
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 pub struct Args {
-    #[arg(
-        long,
-        default_value = "wss://icebreakers1.platform.blockfrost.io/sdk/ws"
-    )]
-    pub gateway_ws_url: String,
+    /// Override the Gateway URL (default: derived from network). Useful for
+    /// self-hosted gateways or testing.
+    #[arg(long)]
+    pub gateway_url: Option<String>,
 
     #[arg(long, default_value = "127.0.0.1:3002")]
     pub listen_address: String,
@@ -42,7 +41,11 @@ impl BridgeConfig {
             .listen_address
             .parse::<SocketAddr>()
             .map_err(|err| anyhow!("Invalid listen address: {err}"))?;
-        let gateway_ws_url = normalize_gateway_ws_url(&args.gateway_ws_url)?;
+
+        let gateway_base_url = args
+            .gateway_url
+            .unwrap_or_else(|| args.network.to_common().default_gateway_url().to_string());
+        let gateway_ws_url = normalize_gateway_ws_url(&gateway_base_url)?;
 
         Ok(Self {
             gateway_ws_url,

--- a/crates/sdk_bridge/src/types.rs
+++ b/crates/sdk_bridge/src/types.rs
@@ -1,3 +1,4 @@
+use bf_common::types::Network as CommonNetwork;
 use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 
@@ -15,6 +16,14 @@ impl Network {
             Self::Mainnet => "mainnet",
             Self::Preprod => "preprod",
             Self::Preview => "preview",
+        }
+    }
+
+    pub fn to_common(&self) -> CommonNetwork {
+        match self {
+            Self::Mainnet => CommonNetwork::Mainnet,
+            Self::Preprod => CommonNetwork::Preprod,
+            Self::Preview => CommonNetwork::Preview,
         }
     }
 }

--- a/flake.nix
+++ b/flake.nix
@@ -196,6 +196,9 @@
             archive = lib.genAttrs (config.systems ++ crossSystems) (
               targetSystem: inputs.self.internal.${targetSystem}.archive
             );
+            archive-bridge = lib.genAttrs config.systems (
+              targetSystem: inputs.self.internal.${targetSystem}.archive-bridge
+            );
             installer = {
               x86_64-windows = inputs.self.internal.x86_64-windows.installer;
               x86_64-darwin = inputs.self.internal.x86_64-darwin.installer;

--- a/nix/internal/darwin.nix
+++ b/nix/internal/darwin.nix
@@ -53,10 +53,9 @@ in
           chmod -R +w $out
           ${with pkgs; lib.getExe rsync} -a ${bundle-dolos}/. $out/libexec/.
           ${with pkgs; lib.getExe rsync} -a ${bundle-hydra}/. $out/libexec/.
-          ${with pkgs; lib.getExe rsync} -a ${bundle-cardano-cli}/. $out/libexec/.
           chmod -R +w $out
 
-          ( cd $out/bin ; ln -s ../libexec/{${unix.packageName.pname},dolos,hydra-node,cardano-cli} ./ ; )
+          ( cd $out/bin ; ln -s ../libexec/{${unix.packageName.pname},dolos,hydra-node} ./ ; )
         '';
     });
 
@@ -65,8 +64,6 @@ in
     bundle-dolos = nix-bundle-exe-lib-subdir "${unix.dolos}/bin/dolos";
 
     bundle-hydra = nix-bundle-exe-lib-subdir "${unix.hydra-node}/bin/hydra-node";
-
-    bundle-cardano-cli = nix-bundle-exe-lib-subdir "${unix.cardano-cli}/bin/cardano-cli";
 
     # Contents of the <https://github.com/blockfrost/homebrew-tap>
     # repo. We replace that workdir on each release.

--- a/nix/internal/darwin.nix
+++ b/nix/internal/darwin.nix
@@ -52,10 +52,12 @@ in
 
           chmod -R +w $out
           ${with pkgs; lib.getExe rsync} -a ${bundle-dolos}/. $out/libexec/.
-          ${with pkgs; lib.getExe rsync} -a ${bundle-hydra}/. $out/libexec/.
+          chmod -R +w $out
+          mkdir -p $out/libexec/hydra-node
+          ${with pkgs; lib.getExe rsync} -a ${bundle-hydra}/. $out/libexec/hydra-node/.
           chmod -R +w $out
 
-          ( cd $out/bin ; ln -s ../libexec/{${unix.packageName.pname},dolos,hydra-node} ./ ; )
+          ( cd $out/bin ; ln -s ../libexec/{${unix.packageName.pname},dolos} ./ ; )
         '';
     });
 

--- a/nix/internal/darwin.nix
+++ b/nix/internal/darwin.nix
@@ -79,10 +79,11 @@ in
           mkdir -p $out/bin
 
           chmod -R +w $out
-          ${with pkgs; lib.getExe rsync} -a ${bundle-hydra}/. $out/libexec/.
+          mkdir -p $out/libexec/hydra-node
+          ${with pkgs; lib.getExe rsync} -a ${bundle-hydra}/. $out/libexec/hydra-node/.
           chmod -R +w $out
 
-          ( cd $out/bin ; ln -s ../libexec/{${unix.packageName.pname},hydra-node} ./ ; )
+          ( cd $out/bin ; ln -s ../libexec/${unix.sdkBridgeCargoToml.package.name} ./ ; )
         '';
     });
 

--- a/nix/internal/darwin.nix
+++ b/nix/internal/darwin.nix
@@ -65,6 +65,25 @@ in
 
     bundle-hydra = nix-bundle-exe-lib-subdir "${unix.hydra-node}/bin/hydra-node";
 
+    # Portable directory that can be run on any modern Darwin:
+    bundle-bridge = (nix-bundle-exe-lib-subdir "${unix.blockfrost-sdk-bridge}/libexec/${unix.sdkBridgeCargoToml.package.name}")
+      .overrideAttrs (drv: {
+      name = unix.sdkBridgeCargoToml.package.name;
+      buildCommand =
+        drv.buildCommand
+        + ''
+          mkdir -p $out/libexec
+          mv $out/{${unix.sdkBridgeCargoToml.package.name},lib} $out/libexec
+          mkdir -p $out/bin
+
+          chmod -R +w $out
+          ${with pkgs; lib.getExe rsync} -a ${bundle-hydra}/. $out/libexec/.
+          chmod -R +w $out
+
+          ( cd $out/bin ; ln -s ../libexec/{${unix.packageName.pname},hydra-node} ./ ; )
+        '';
+    });
+
     # Contents of the <https://github.com/blockfrost/homebrew-tap>
     # repo. We replace that workdir on each release.
     homebrew-tap =

--- a/nix/internal/darwin.nix
+++ b/nix/internal/darwin.nix
@@ -68,7 +68,7 @@ in
     # Portable directory that can be run on any modern Darwin:
     bundle-bridge = (nix-bundle-exe-lib-subdir "${unix.blockfrost-sdk-bridge}/libexec/${unix.sdkBridgeCargoToml.package.name}")
       .overrideAttrs (drv: {
-      name = unix.sdkBridgeCargoToml.package.name;
+      inherit (unix.sdkBridgeCargoToml.package) name;
       buildCommand =
         drv.buildCommand
         + ''

--- a/nix/internal/darwin.nix
+++ b/nix/internal/darwin.nix
@@ -84,6 +84,22 @@ in
         '';
     });
 
+    archive-bridge = let
+      outFileName = "${unix.sdkBridgeCargoToml.package.name}-${unix.blockfrost-platform.version}-${inputs.self.shortRev or "dirty"}-${targetSystem}.tar.bz2";
+    in
+      pkgs.runCommandNoCC "${unix.sdkBridgeCargoToml.package.name}-archive" {
+        passthru = {inherit outFileName;};
+      } ''
+        cp -r ${bundle-bridge} ${unix.sdkBridgeCargoToml.package.name}
+
+        mkdir -p $out
+        tar -cjvf $out/${outFileName} ${unix.sdkBridgeCargoToml.package.name}/
+
+        # Make it downloadable from Hydra:
+        mkdir -p $out/nix-support
+        echo "file binary-dist \"$out/${outFileName}\"" >$out/nix-support/hydra-build-products
+      '';
+
     # Contents of the <https://github.com/blockfrost/homebrew-tap>
     # repo. We replace that workdir on each release.
     homebrew-tap =

--- a/nix/internal/hydra-bridge-gateway-test.sh
+++ b/nix/internal/hydra-bridge-gateway-test.sh
@@ -350,7 +350,7 @@ log info "Gateway is up at ${gateway_url}"
 log info "Starting the SDK Bridge (blockfrost-sdk-bridge)…"
 
 blockfrost-sdk-bridge \
-  --gateway-ws-url "${gateway_url}" \
+  --gateway-url "${gateway_url}" \
   --listen-address "127.0.0.1:${bridge_port}" \
   --network "${NETWORK}" \
   --blockfrost-project-id "${BLOCKFROST_PROJECT_ID}" \

--- a/nix/internal/hydra-bridge-gateway-test.sh
+++ b/nix/internal/hydra-bridge-gateway-test.sh
@@ -7,7 +7,7 @@
 # `dev_mock_db`, receiver):
 #
 # 1. Start the Gateway with a `[hydra_bridge]` config section
-# 2. Start the SDK Bridge pointing at the local Gateway (`--gateway-ws-url`)
+# 2. Start the SDK Bridge pointing at the local Gateway (`--gateway-url`)
 # 3. Wait for Hydra key exchange, Head Init, Commit, and Open
 # 4. Send API requests through the SDK Bridge -> Gateway
 # 5. Verify that the Gateway triggers Close -> Fanout after enough micropayments

--- a/nix/internal/linux.nix
+++ b/nix/internal/linux.nix
@@ -59,4 +59,38 @@ in
       exe_dir = "exe";
       lib_dir = "lib";
     } "${unix.hydra-node}/bin/hydra-node";
+
+    # Portable directory that can be run on any modern Linux:
+    bundle-bridge =
+      (nix-bundle-exe {
+        inherit pkgs;
+        bin_dir = "bin";
+        exe_dir = "exe";
+        lib_dir = "lib";
+      } "${unix.blockfrost-sdk-bridge}/libexec/${unix.sdkBridgeCargoToml.package.name}")
+      .overrideAttrs (drv: {
+        name = unix.sdkBridgeCargoToml.package.name;
+        buildCommand =
+          drv.buildCommand
+          + ''
+            chmod -R +w $out
+            ${with pkgs; lib.getExe rsync} -a ${bundle-hydra}/. $out/.
+            chmod -R +w $out
+            ( cd $out ; ln -s bin/{${unix.sdkBridgeCargoToml.package.name},hydra-node} ./ ; )
+          '';
+      });
+
+    archive-bridge = let
+      outFileName = "${unix.sdkBridgeCargoToml.package.name}-${unix.blockfrost-platform.version}-${inputs.self.shortRev or "dirty"}-${targetSystem}.tar.bz2";
+    in
+      pkgs.runCommandNoCC "${unix.sdkBridgeCargoToml.package.name}-archive" {} ''
+        cp -r ${bundle-bridge} ${unix.sdkBridgeCargoToml.package.name}
+
+        mkdir -p $out
+        tar -cjvf $out/${outFileName} ${unix.sdkBridgeCargoToml.package.name}/
+
+        # Make it downloadable from Hydra:
+        mkdir -p $out/nix-support
+        echo "file binary-dist \"$out/${outFileName}\"" >$out/nix-support/hydra-build-products
+      '';
   }

--- a/nix/internal/linux.nix
+++ b/nix/internal/linux.nix
@@ -69,7 +69,7 @@ in
         lib_dir = "lib";
       } "${unix.blockfrost-sdk-bridge}/libexec/${unix.sdkBridgeCargoToml.package.name}")
       .overrideAttrs (drv: {
-        name = unix.sdkBridgeCargoToml.package.name;
+        inherit (unix.sdkBridgeCargoToml.package) name;
         buildCommand =
           drv.buildCommand
           + ''

--- a/nix/internal/linux.nix
+++ b/nix/internal/linux.nix
@@ -41,9 +41,8 @@ in
             chmod -R +w $out
             ${with pkgs; lib.getExe rsync} -a ${bundle-dolos}/. $out/.
             ${with pkgs; lib.getExe rsync} -a ${bundle-hydra}/. $out/.
-            ${with pkgs; lib.getExe rsync} -a ${bundle-cardano-cli}/. $out/.
             chmod -R +w $out
-            ( cd $out ; ln -s bin/{${unix.packageName.pname},dolos,hydra-node,cardano-cli} ./ ; )
+            ( cd $out ; ln -s bin/{${unix.packageName.pname},dolos,hydra-node} ./ ; )
           '';
       });
 
@@ -60,11 +59,4 @@ in
       exe_dir = "exe";
       lib_dir = "lib";
     } "${unix.hydra-node}/bin/hydra-node";
-
-    bundle-cardano-cli = nix-bundle-exe {
-      inherit pkgs;
-      bin_dir = "bin";
-      exe_dir = "exe";
-      lib_dir = "lib";
-    } "${unix.cardano-cli}/bin/cardano-cli";
   }

--- a/nix/internal/unix.nix
+++ b/nix/internal/unix.nix
@@ -91,40 +91,30 @@ in
         };
       });
 
-    blockfrost-gateway = craneLib.buildPackage (commonArgs
-      // {
-        inherit cargoArtifacts GIT_REVISION;
-        pname = gatewayCargoToml.package.name;
-        doCheck = false; # we run tests with `cargo-nextest` below
-        meta.mainProgram = gatewayCargoToml.package.name;
-        postInstall = ''
-          mv $out/bin $out/libexec
-          mkdir -p $out/bin
-          ( cd $out/bin && ln -s ../libexec/${gatewayCargoToml.package.name} ./ ; )
-          ln -s ${hydra-node}/bin/hydra-node $out/libexec/
-        '';
-        cargoExtraArgs = "--package blockfrost-gateway";
-      }
-      // (builtins.listToAttrs hydraScriptsEnvVars));
+    mk-blockfrost-gateway = {mockDb ? false}:
+      craneLib.buildPackage (commonArgs
+        // {
+          inherit cargoArtifacts GIT_REVISION;
+          pname = gatewayCargoToml.package.name + lib.optionalString mockDb "-dev-mock-db";
+          doCheck = false; # we run tests with `cargo-nextest` below
+          meta = {
+            mainProgram = gatewayCargoToml.package.name;
+            description = "Blockfrost Gateway" + lib.optionalString mockDb " (dev mock DB build)";
+          };
+          postInstall = ''
+            mv $out/bin $out/libexec
+            mkdir -p $out/bin
+            ( cd $out/bin && ln -s ../libexec/${gatewayCargoToml.package.name} ./ ; )
+            mkdir -p $out/libexec/hydra-node/
+            ln -s ${hydra-node}/bin/hydra-node $out/libexec/hydra-node/
+          '';
+          cargoExtraArgs = "--package blockfrost-gateway" + lib.optionalString mockDb " --features dev_mock_db";
+        }
+        // (builtins.listToAttrs hydraScriptsEnvVars));
 
-    blockfrost-gateway--dev-mock-db = craneLib.buildPackage (commonArgs
-      // {
-        inherit cargoArtifacts GIT_REVISION;
-        pname = gatewayCargoToml.package.name + "-dev-mock-db";
-        doCheck = false; # we run tests with `cargo-nextest` below
-        meta = {
-          mainProgram = gatewayCargoToml.package.name;
-          description = "Blockfrost Gateway (dev mock DB build)";
-        };
-        postInstall = ''
-          mv $out/bin $out/libexec
-          mkdir -p $out/bin
-          ( cd $out/bin && ln -s ../libexec/${gatewayCargoToml.package.name} ./ ; )
-          ln -s ${hydra-node}/bin/hydra-node $out/libexec/
-        '';
-        cargoExtraArgs = "--package blockfrost-gateway --features dev_mock_db";
-      }
-      // (builtins.listToAttrs hydraScriptsEnvVars));
+    blockfrost-gateway = mk-blockfrost-gateway {mockDb = false;};
+
+    blockfrost-gateway--dev-mock-db = mk-blockfrost-gateway {mockDb = true;};
 
     blockfrost-sdk-bridge = craneLib.buildPackage (commonArgs
       // {

--- a/nix/internal/unix.nix
+++ b/nix/internal/unix.nix
@@ -79,7 +79,9 @@ in
           chmod -R +w $out
           mv $out/bin $out/libexec
           mkdir -p $out/bin
-          ln -sf $out/libexec/${packageName.pname} $out/bin/
+          ( cd $out/bin && ln -s ../libexec/${packageName.pname} ./ ; )
+          mkdir -p $out/libexec/hydra-node/
+          ln -s ${hydra-node}/bin/hydra-node $out/libexec/hydra-node/
         '';
         meta = {
           mainProgram = packageName.pname;

--- a/nix/internal/unix.nix
+++ b/nix/internal/unix.nix
@@ -126,6 +126,8 @@ in
           mv $out/bin $out/libexec
           mkdir -p $out/bin
           ( cd $out/bin && ln -s ../libexec/${sdkBridgeCargoToml.package.name} ./ ; )
+          mkdir -p $out/libexec/hydra-node/
+          ln -s ${hydra-node}/bin/hydra-node $out/libexec/hydra-node/
         '';
         cargoExtraArgs = "--package blockfrost-sdk-bridge";
       });


### PR DESCRIPTION
## Context

Verify that the following launch correctly, can find `hydra-node`, etc.

- [x] Platform
  - [x] Linux: portable bundle
  - [x] Linux: installer (synthetic `curl-bash-install.sh`)
  - [x] Linux: Nix package
  - [x] macOS: portable bundle
  - [x] macOS: installer (synthetic `curl-bash-install.sh`)
  - [x] macOS: Nix package
  - [x] Windows: portable bundle
  - [x] Windows: installer

- [x] SDK Bridge
  - [x] Linux: portable bundle
  - [x] Linux: Nix package
  - [x] macOS: portable bundle
  - [x] macOS: Nix package
  - [x] ~~Windows: unsupported ([no `hydra-node`](https://github.com/cardano-scaling/hydra/issues/2360))~~

- [x] Gateway
  - [x] Linux: Nix package
  - [x] macOS: Nix package