### PR TITLE
fix(hydra): reset stale credits on Head `Close` and seed Gateway balance on `Open`

### DIFF
--- a/crates/gateway/src/hydra_server_bridge/mod.rs
+++ b/crates/gateway/src/hydra_server_bridge/mod.rs
@@ -611,8 +611,19 @@ impl State {
                     self.customer_log_id, status
                 );
                 if status == "Open" {
+                    // Seed credits_last_balance from the current snapshot so
+                    // that MonitorCredits does not double-count pre-existing
+                    // funds (e.g. after a hydra-node crash-restart that
+                    // re-joins an already-Open head).
+                    let initial_balance = verifications::lovelace_in_snapshot_for_address(
+                        self.api_port,
+                        &self.config.gateway_cardano_addr,
+                    )
+                    .await
+                    .unwrap_or(0);
+
                     self.hydra_head_open = true;
-                    self.credits_last_balance = 0;
+                    self.credits_last_balance = initial_balance;
                     self.received_microtransactions = 0;
                     self.send_delayed(Event::MonitorCredits, CREDIT_POLL_INTERVAL)
                         .await;

--- a/crates/gateway/src/load_balancer.rs
+++ b/crates/gateway/src/load_balancer.rs
@@ -595,7 +595,13 @@ pub mod event_loop {
                                 },
                             }
                         },
-                        (Some(hydras), _, _) => {
+                        // Stale finalize: no pending initial KEx to match against.
+                        (Some(_), Some(_), false) => LoadBalancerMessage::Error {
+                            code: 537,
+                            msg: "Hydra micropayments setup error: no pending key exchange; please re-initiate".to_string(),
+                        },
+                        // Initial step: start a new key exchange.
+                        (Some(hydras), None, _) => {
                             match hydras
                                 .initialize_key_exchange(asset_name, req.clone())
                                 .await

--- a/crates/gateway/src/sdk_bridge_ws.rs
+++ b/crates/gateway/src/sdk_bridge_ws.rs
@@ -174,17 +174,20 @@ pub mod event_loop {
                     let reply = match (
                         &state.hydras,
                         &req.accepted_platform_h2h_port,
-                        initial_hydra_kex.as_ref(),
+                        initial_hydra_kex.is_some(),
                     ) {
                         (None, _, _) => GatewayMessage::Error {
                             code: 536,
                             msg: "Hydra micropayments not supported".to_string(),
                         },
-                        (Some(hydras), Some(_accepted_port), Some(_)) => {
-                            let initial_kex = initial_hydra_kex.take().unwrap();
+                        // Finalize step: bridge accepted the proposed port.
+                        (Some(hydras), Some(_accepted_port), true) => {
+                            let initial_kex = initial_hydra_kex.clone().unwrap();
                             let bridge_machine_id = req.machine_id.clone();
                             match hydras.spawn_new(initial_kex, req).await {
                                 Ok((ctl, resp)) => {
+                                    // Consume the cached KEx only after spawn succeeds:
+                                    initial_hydra_kex = None;
                                     hydra_controller = Some(ctl);
 
                                     // Only start the TCP-over-WebSocket tunnels if we’re running
@@ -228,7 +231,13 @@ pub mod event_loop {
                                 },
                             }
                         },
-                        (Some(hydras), _, _) => {
+                        // Stale finalize: no pending initial KEx to match against.
+                        (Some(_), Some(_), false) => GatewayMessage::Error {
+                            code: 537,
+                            msg: "Hydra micropayments setup error: no pending key exchange; please re-initiate".to_string(),
+                        },
+                        // Initial step: start a new key exchange.
+                        (Some(hydras), None, _) => {
                             match hydras.initialize_key_exchange(req.clone()).await {
                                 Ok(resp) => {
                                     initial_hydra_kex = Some((req, resp.clone()));

--- a/crates/platform/src/hydra_client/mod.rs
+++ b/crates/platform/src/hydra_client/mod.rs
@@ -107,6 +107,10 @@ struct State {
     /// Incremented on every [`Event::Restart`] so that delayed events from a
     /// previous epoch are silently dropped instead of piling up.
     restart_gen: Arc<AtomicU64>,
+    /// Snapshot of [`Self::restart_gen`] captured when the current key-exchange
+    /// round was initiated. Used to discard stale [`KeyExchangeResponse`]s
+    /// that arrive after a newer restart has already begun.
+    kex_restart_gen: u64,
 }
 
 impl State {
@@ -169,6 +173,7 @@ impl State {
             hydra_pid: None,
             hydra_watchdog: None,
             restart_gen: Arc::new(AtomicU64::new(0)),
+            kex_restart_gen: 0,
         };
 
         self_.send(Event::Restart).await;
@@ -257,6 +262,7 @@ impl State {
                 // Invalidate all delayed events from the previous epoch so
                 // they do not pile up into parallel polling chains.
                 self.restart_gen.fetch_add(1, Ordering::Relaxed);
+                self.kex_restart_gen = self.restart_gen.load(Ordering::Relaxed);
                 // Kill leftover hydra-node + descendants (e.g. etcd) from the
                 // previous run, if any.
                 self.stop_hydra_node().await;
@@ -287,6 +293,12 @@ impl State {
                     kex_done: false, ..
                 },
             ) => {
+                // A newer restart may have already begun a fresh KEx round;
+                // discard responses belonging to an older round.
+                if self.restart_gen.load(Ordering::Relaxed) != self.kex_restart_gen {
+                    debug!("discarding stale KEx response (restart happened since)");
+                    return Ok(());
+                }
                 if !(matches!(
                     verifications::is_tcp_port_free(kex_resp.gateway_h2h_port).await,
                     Ok(true)
@@ -311,6 +323,10 @@ impl State {
             },
 
             Event::KeyExchangeResponse(kex_resp @ KeyExchangeResponse { kex_done: true, .. }) => {
+                if self.restart_gen.load(Ordering::Relaxed) != self.kex_restart_gen {
+                    debug!("discarding stale KEx response (restart happened since)");
+                    return Ok(());
+                }
                 // Check that we have enough fuel lovelace for L1 fees by
                 // querying the local cardano-node via Pallas.
                 let potential_fuel = self

--- a/crates/sdk_bridge/src/hydra_client/mod.rs
+++ b/crates/sdk_bridge/src/hydra_client/mod.rs
@@ -191,6 +191,10 @@ struct State {
     /// Incremented on every [`Event::Restart`] so that delayed events from a
     /// previous epoch are silently dropped instead of piling up.
     restart_gen: Arc<AtomicU64>,
+    /// Snapshot of [`Self::restart_gen`] captured when the current key-exchange
+    /// round was initiated. Used to discard stale [`KeyExchangeResponse`]s
+    /// that arrive after a newer restart has already begun.
+    kex_restart_gen: u64,
     hydra_head_open: bool,
     head_open_initialized: bool,
     credits_available: Arc<AtomicU64>,
@@ -258,6 +262,7 @@ impl State {
             hydra_pid: None,
             hydra_watchdog: None,
             restart_gen: Arc::new(AtomicU64::new(0)),
+            kex_restart_gen: 0,
             hydra_head_open: false,
             head_open_initialized: false,
             credits_available,
@@ -362,6 +367,7 @@ impl State {
                 // Invalidate all delayed events from the previous epoch so
                 // they do not pile up into parallel polling chains.
                 self.restart_gen.fetch_add(1, Ordering::Relaxed);
+                self.kex_restart_gen = self.restart_gen.load(Ordering::Relaxed);
                 // Kill leftover hydra-node + descendants (e.g. etcd) from the
                 // previous run, if any.
                 self.stop_hydra_node().await;
@@ -414,6 +420,12 @@ impl State {
                     kex_done: false, ..
                 },
             ) => {
+                // A newer restart may have already begun a fresh KEx round;
+                // discard responses belonging to an older round.
+                if self.restart_gen.load(Ordering::Relaxed) != self.kex_restart_gen {
+                    debug!("discarding stale KEx response (restart happened since)");
+                    return Ok(());
+                }
                 let params = PaymentParams {
                     commit_ada: kex_resp.commit_ada,
                     lovelace_per_request: kex_resp.lovelace_per_request,
@@ -460,6 +472,10 @@ impl State {
             },
 
             Event::KeyExchangeResponse(kex_resp @ KeyExchangeResponse { kex_done: true, .. }) => {
+                if self.restart_gen.load(Ordering::Relaxed) != self.kex_restart_gen {
+                    debug!("discarding stale KEx response (restart happened since)");
+                    return Ok(());
+                }
                 if self.gateway_payment_addr.is_empty() {
                     let addr = self
                         .derive_enterprise_address_from_vkey_json(&kex_resp.gateway_cardano_vkey)?;

--- a/crates/sdk_bridge/src/hydra_client/mod.rs
+++ b/crates/sdk_bridge/src/hydra_client/mod.rs
@@ -639,6 +639,7 @@ impl State {
                     self.on_head_open().await?;
                 } else {
                     self.hydra_head_open = false;
+                    self.credits_available.store(0, Ordering::SeqCst);
                     self.credits_last_balance = 0;
                     self.head_open_initialized = false;
                 }
@@ -899,6 +900,7 @@ impl State {
 
         self.head_open_initialized = true;
         self.hydra_head_open = true;
+        self.credits_available.store(0, Ordering::SeqCst);
         self.credits_last_balance = 0;
         self.accounted_requests = 0;
         self.sent_microtransactions = 0;

--- a/nix/internal/hydra-bridge-gateway-test.sh
+++ b/nix/internal/hydra-bridge-gateway-test.sh
@@ -530,7 +530,10 @@ perform_fanout_cycle() {
     wait_for_gw_log_count 'waiting for the Open head status: status="Open"' "$head_opens_seen" "$fanout_wait_timeout" \
       "Fanout $fanout_num: head reopen" || exit 1
     log info "Fanout $fanout_num: head is Open again. Waiting for Bridge credits…"
-    bridge_credits_seen=$((bridge_credits_seen + 1))
+    # Snapshot the current count so we wait for a genuinely NEW credit grant
+    # from the new head session (stale entries from previous cycles must not
+    # satisfy the check since credits_available is reset on head close).
+    bridge_credits_seen=$(($(bridge_log_count "req. credits +") + 1))
     # Same lag as above: Bridge may take 20+ s to see Open + 15 s prepay delay.
     wait_for_bridge_log_count "req. credits +" "$bridge_credits_seen" 90 \
       "Fanout $fanout_num: Bridge credits" || exit 1


### PR DESCRIPTION
## Context

### Issue 1

Resolves:
- https://github.com/blockfrost/blockfrost-platform/actions/runs/24190234830/job/70615404273

After a `hydra-node` crash-restart that re-joins an `Open` head, the Bridge kept stale `credits_available` allowing HTTP 200 responses while `AccountOneRequest` retried forever (Head not `Open`). The Gateway also double-counted the existing snapshot balance as new microtransactions, triggering a spurious Close.

- Bridge: zero `credits_available` in `MonitorStates` when head leaves `Open` and in `on_head_open()` as a defense.

- Gateway: seed `credits_last_balance` from the current snapshot in `WaitForOpen` so only genuinely new deposits are counted.

### Issue 2

Fixes:
- <https://github.com/blockfrost/blockfrost-platform/actions/runs/24266878515/job/70864753840?pr=522>

When both `hydra-node`s crashed, multiple `Event::Restart` events would pile up, each initiating a new KEx round. Responses from older rounds would then race on the gateway's single-session state, causing port mismatches and permanently preventing recovery.