### PR TITLE
fix(tests): unignore certain tests ignored in #509 for a green `main`

### DIFF
--- a/crates/integration_tests/tests/data/ignored_tests.json
+++ b/crates/integration_tests/tests/data/ignored_tests.json
@@ -249,10 +249,6 @@
     {
       "_comment": "accounts/stake_test1urvp7670m5ec50fz5dekdu5e8pycx62ys2fkuu80m5v823q59qmel/registrations?count=2&page=1, accounts/stake_test1urvp7670m5ec50fz5dekdu5e8pycx62ys2fkuu80m5v823q59qmel/registrations?count=2&page=1&order=asc",
       "id": "accounts-stake-address-queryparams-generic-stake-address-registrations_40bbd32ffbe9"
-    },
-    {
-      "_comment": "pools/extended?count=5&page=3, pools/extended?count=5&page=3&order=asc",
-      "id": "pools-extended-queryparams_33c8fc92f5c2"
     }
   ],
   "preview": [


### PR DESCRIPTION
## Context

Some Preprod tests started passing on `main`:
- https://github.com/blockfrost/blockfrost-platform/actions/runs/24211277203/job/70755851812

The ones ignored in:
- #509 

Let's try unignoring.