### PR TITLE
fix: immediately run the built binaries; fail early if no `hydra-node`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ FROM base AS hydra
 ARG TARGETARCH
 # hadolint ignore=DL3008
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends unzip \
+  && apt-get install -y --no-install-recommends unzip patchelf \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 RUN set -eux; \
@@ -50,11 +50,19 @@ RUN set -eux; \
     curl -fSL -o /tmp/hydra.tar.bz2 \
       "https://github.com/blockfrost/hydra-aarch64-linux/releases/download/1.0.0/hydra-aarch64-linux-1.0.0.tar.bz2" \
     && tar xjf /tmp/hydra.tar.bz2 -C /app/hydra-node \
-    && rm /tmp/hydra.tar.bz2; \
+    && rm /tmp/hydra.tar.bz2 \
+    && patchelf \
+      --set-interpreter /app/hydra-node/lib/ld-linux-aarch64.so.1 \
+      --set-rpath /app/hydra-node/lib \
+      /app/hydra-node/exe/hydra-node \
+    && rm -f /app/hydra-node/hydra-node \
+    && mv /app/hydra-node/exe/hydra-node /app/hydra-node/hydra-node \
+    && rm -rf /app/hydra-node/bin /app/hydra-node/exe; \
   else \
     echo "Unsupported architecture: $TARGETARCH" >&2; exit 1; \
   fi; \
-  chmod +x /app/hydra-node/*
+  chmod +x /app/hydra-node/hydra-node; \
+  /app/hydra-node/hydra-node --version
 
 FROM gcr.io/distroless/cc-debian13@sha256:05d26fe67a875592cd65f26b2bcfadb8830eae53e68945784e39b23e62c382e0 AS runtime
 COPY --from=builder /app/target/release/blockfrost-platform /app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,10 +32,31 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
   --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
   cargo build --release
 
+FROM base AS hydra
+ARG TARGETARCH
+# hadolint ignore=DL3008
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends unzip \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+RUN set -eux; \
+  if [ "$TARGETARCH" = "amd64" ]; then \
+    url="https://github.com/cardano-scaling/hydra/releases/download/1.0.0/hydra-x86_64-linux-1.0.0.zip"; \
+  elif [ "$TARGETARCH" = "arm64" ]; then \
+    url="https://github.com/blockfrost/hydra-aarch64-linux/releases/download/1.0.0/hydra-aarch64-linux-1.0.0.zip"; \
+  else \
+    echo "Unsupported architecture: $TARGETARCH" >&2; exit 1; \
+  fi; \
+  curl -fSL -o /tmp/hydra.zip "$url" \
+  && mkdir -p /app/hydra-node \
+  && unzip /tmp/hydra.zip -d /app/hydra-node \
+  && chmod +x /app/hydra-node/* \
+  && rm /tmp/hydra.zip
+
 FROM gcr.io/distroless/cc-debian13@sha256:05d26fe67a875592cd65f26b2bcfadb8830eae53e68945784e39b23e62c382e0 AS runtime
 COPY --from=builder /app/target/release/blockfrost-platform /app/
-# FIXME: add hydra-node somehow – `aarch64-linux` will be a problem, because it's not published anywhere
-#COPY --from=hydra-node /hydra-node /app/hydra-node/hydra-node
+COPY --from=hydra /app/hydra-node/ /app/hydra-node/
+
 RUN ["/app/blockfrost-platform", "--version"]
 
 ARG GIT_REVISION

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,18 +40,21 @@ RUN apt-get update \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 RUN set -eux; \
+  mkdir -p /app/hydra-node; \
   if [ "$TARGETARCH" = "amd64" ]; then \
-    url="https://github.com/cardano-scaling/hydra/releases/download/1.0.0/hydra-x86_64-linux-1.0.0.zip"; \
+    curl -fSL -o /tmp/hydra.zip \
+      "https://github.com/cardano-scaling/hydra/releases/download/1.0.0/hydra-x86_64-linux-1.0.0.zip" \
+    && unzip /tmp/hydra.zip -d /app/hydra-node \
+    && rm /tmp/hydra.zip; \
   elif [ "$TARGETARCH" = "arm64" ]; then \
-    url="https://github.com/blockfrost/hydra-aarch64-linux/releases/download/1.0.0/hydra-aarch64-linux-1.0.0.zip"; \
+    curl -fSL -o /tmp/hydra.tar.bz2 \
+      "https://github.com/blockfrost/hydra-aarch64-linux/releases/download/1.0.0/hydra-aarch64-linux-1.0.0.tar.bz2" \
+    && tar xjf /tmp/hydra.tar.bz2 -C /app/hydra-node \
+    && rm /tmp/hydra.tar.bz2; \
   else \
     echo "Unsupported architecture: $TARGETARCH" >&2; exit 1; \
   fi; \
-  curl -fSL -o /tmp/hydra.zip "$url" \
-  && mkdir -p /app/hydra-node \
-  && unzip /tmp/hydra.zip -d /app/hydra-node \
-  && chmod +x /app/hydra-node/* \
-  && rm /tmp/hydra.zip
+  chmod +x /app/hydra-node/*
 
 FROM gcr.io/distroless/cc-debian13@sha256:05d26fe67a875592cd65f26b2bcfadb8830eae53e68945784e39b23e62c382e0 AS runtime
 COPY --from=builder /app/target/release/blockfrost-platform /app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,9 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 
 FROM gcr.io/distroless/cc-debian13@sha256:05d26fe67a875592cd65f26b2bcfadb8830eae53e68945784e39b23e62c382e0 AS runtime
 COPY --from=builder /app/target/release/blockfrost-platform /app/
+# FIXME: add hydra-node somehow – `aarch64-linux` will be a problem, because it's not published anywhere
+#COPY --from=hydra-node /hydra-node /app/hydra-node/hydra-node
+RUN ["/app/blockfrost-platform", "--version"]
 
 ARG GIT_REVISION
 LABEL org.opencontainers.image.title="Blockfrost platform" \

--- a/crates/gateway/src/main.rs
+++ b/crates/gateway/src/main.rs
@@ -17,6 +17,15 @@ use tracing_subscriber::fmt::format::Format;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Fail early if hydra-node is not found (not applicable on Windows).
+    #[cfg(not(target_os = "windows"))]
+    if let Err(e) =
+        bf_common::find_libexec::find_libexec("hydra-node", "HYDRA_NODE_PATH", &["--version"])
+    {
+        eprintln!("Error: {e}");
+        std::process::exit(1);
+    }
+
     dotenvy::dotenv().ok();
 
     let arguments = Args::parse();

--- a/crates/platform/src/main.rs
+++ b/crates/platform/src/main.rs
@@ -14,6 +14,15 @@ use tracing::{info, warn};
 
 #[tokio::main]
 async fn main() -> Result<(), AppError> {
+    // Fail early if hydra-node is not found (not applicable on Windows).
+    #[cfg(not(target_os = "windows"))]
+    if let Err(e) =
+        bf_common::find_libexec::find_libexec("hydra-node", "HYDRA_NODE_PATH", &["--version"])
+    {
+        eprintln!("Error: {e}");
+        std::process::exit(1);
+    }
+
     dotenv().ok();
     let config = Args::init().await?;
 

--- a/crates/sdk_bridge/src/main.rs
+++ b/crates/sdk_bridge/src/main.rs
@@ -12,6 +12,15 @@ use tracing_subscriber::fmt::format::Format;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Fail early if hydra-node is not found (not applicable on Windows).
+    #[cfg(not(target_os = "windows"))]
+    if let Err(e) =
+        bf_common::find_libexec::find_libexec("hydra-node", "HYDRA_NODE_PATH", &["--version"])
+    {
+        eprintln!("Error: {e}");
+        std::process::exit(1);
+    }
+
     let args = config::Args::parse();
     let config = config::BridgeConfig::from_args(args)?;
 

--- a/nix/internal/darwin.nix
+++ b/nix/internal/darwin.nix
@@ -58,6 +58,7 @@ in
           chmod -R +w $out
 
           ( cd $out/bin ; ln -s ../libexec/{${unix.packageName.pname},dolos} ./ ; )
+          $out/bin/${unix.packageName.pname} --version
         '';
     });
 
@@ -84,6 +85,7 @@ in
           chmod -R +w $out
 
           ( cd $out/bin ; ln -s ../libexec/${unix.sdkBridgeCargoToml.package.name} ./ ; )
+          $out/bin/${unix.sdkBridgeCargoToml.package.name} --version
         '';
     });
 

--- a/nix/internal/linux.nix
+++ b/nix/internal/linux.nix
@@ -43,6 +43,7 @@ in
             ${with pkgs; lib.getExe rsync} -a ${bundle-hydra}/. $out/.
             chmod -R +w $out
             ( cd $out ; ln -s bin/{${unix.packageName.pname},dolos,hydra-node} ./ ; )
+            $out/bin/${unix.packageName.pname} --version
           '';
       });
 
@@ -77,6 +78,7 @@ in
             ${with pkgs; lib.getExe rsync} -a ${bundle-hydra}/. $out/.
             chmod -R +w $out
             ( cd $out ; ln -s bin/{${unix.sdkBridgeCargoToml.package.name},hydra-node} ./ ; )
+            $out/bin/${unix.sdkBridgeCargoToml.package.name} --version
           '';
       });
 

--- a/nix/internal/unix.nix
+++ b/nix/internal/unix.nix
@@ -82,6 +82,7 @@ in
           ( cd $out/bin && ln -s ../libexec/${packageName.pname} ./ ; )
           mkdir -p $out/libexec/hydra-node/
           ln -s ${hydra-node}/bin/hydra-node $out/libexec/hydra-node/
+          $out/bin/${packageName.pname} --version
         '';
         meta = {
           mainProgram = packageName.pname;
@@ -109,6 +110,7 @@ in
             ( cd $out/bin && ln -s ../libexec/${gatewayCargoToml.package.name} ./ ; )
             mkdir -p $out/libexec/hydra-node/
             ln -s ${hydra-node}/bin/hydra-node $out/libexec/hydra-node/
+            $out/bin/${gatewayCargoToml.package.name} --version
           '';
           cargoExtraArgs = "--package blockfrost-gateway" + lib.optionalString mockDb " --features dev_mock_db";
         }
@@ -130,6 +132,7 @@ in
           ( cd $out/bin && ln -s ../libexec/${sdkBridgeCargoToml.package.name} ./ ; )
           mkdir -p $out/libexec/hydra-node/
           ln -s ${hydra-node}/bin/hydra-node $out/libexec/hydra-node/
+          $out/bin/${sdkBridgeCargoToml.package.name} --version
         '';
         cargoExtraArgs = "--package blockfrost-sdk-bridge";
       });

--- a/nix/internal/windows.nix
+++ b/nix/internal/windows.nix
@@ -128,6 +128,7 @@ in rec {
       projectName = blockfrost-platform.pname;
       projectVersion = blockfrost-platform.version;
       WINEDEBUG = "-all"; # comment out to get normal output (err,fixme), or set to +all for a flood
+      WINEDLLOVERRIDES = "mscoree,mshtml="; # don't ask about Mono or Gecko
     } ''
       mkdir home
       export HOME=$(realpath home)
@@ -224,11 +225,19 @@ in rec {
 
   # XXX: there’s no Hydra build for Windows currently, as `hydra-cluster`
   # depends on the `unix` package, see <https://github.com/cardano-scaling/hydra/issues/2360>.
-  bundle = pkgs.runCommandNoCC "bundle" {} ''
-    mkdir -p $out
-    cp -r ${packageWithIcon}/. $out/.
-    cp -r ${dolos}/bin/. $out/.
-  '';
+  bundle =
+    pkgs.runCommandNoCC "bundle" {
+      buildInputs = [pkgs.wine64];
+      WINEDEBUG = "-all";
+      WINEDLLOVERRIDES = "mscoree,mshtml="; # don't ask about Mono or Gecko
+    } ''
+      mkdir home
+      export HOME=$(realpath home)
+      mkdir -p $out
+      cp -r ${packageWithIcon}/. $out/.
+      cp -r ${dolos}/bin/. $out/.
+      wine64 $out/${packageName.pname}.exe --version
+    '';
 
   archive =
     pkgs.runCommandNoCC "archive"
@@ -310,6 +319,7 @@ in rec {
         samba # samba is for bin/ntlm_auth
       ];
       WINEDEBUG = "-all"; # comment out to get normal output (err,fixme), or set to +all for a flood
+      WINEDLLOVERRIDES = "mscoree,mshtml="; # don't ask about Mono or Gecko
     } ''
       export HOME=$(realpath $NIX_BUILD_TOP/home)
       mkdir -p $HOME


### PR DESCRIPTION
## Context

- An idea I had – let’s run each binary with `--version` right after it's been built/

- But also fail immediately in `fn main` when the helper binaries are not available.

- Since we treat the helper binaries as "functions", this checks that the entire service is "loaded" correctly.

- One bug was already found – we didn’t add `hydra-node` to the `Dockerfile`

  - … which is a problem, because they're not publishing `aarch64-linux` binaries or images… https://github.com/cardano-scaling/hydra/releases/tag/1.0.0 – and we have multi-arch images.

  - To solve it, I zipped the result of `nix build --builders '' --max-jobs 0 -L .#internal.aarch64-linux.bundle-hydra` locally, and published to https://github.com/blockfrost/hydra-aarch64-linux/releases/tag/1.0.0 – I think it should be good enough…