### PR TITLE
fix(sdk-bridge): correct naming of some protocol fields (`platform` → `bridge`)

### DIFF
--- a/crates/gateway/src/hydra_server_bridge/mod.rs
+++ b/crates/gateway/src/hydra_server_bridge/mod.rs
@@ -71,8 +71,8 @@ impl HydrasManager {
         &self,
         req: KeyExchangeRequest,
     ) -> Result<KeyExchangeResponse> {
-        if req.accepted_platform_h2h_port.is_some() {
-            bail!("`accepted_platform_h2h_port` must not be set in `initialize_key_exchange`")
+        if req.accepted_bridge_h2h_port.is_some() {
+            bail!("`accepted_bridge_h2h_port` must not be set in `initialize_key_exchange`")
         }
 
         let cur_count = Arc::strong_count(self.controller_counter.as_ref()).saturating_sub(1);
@@ -114,7 +114,7 @@ impl HydrasManager {
             hydra_scripts_tx_id: hydra_scripts_tx_id(&self.config.network).to_string(),
             protocol_parameters: self.config.protocol_parameters.clone(),
             contestation_period: CONTESTATION_PERIOD_SECONDS,
-            proposed_platform_h2h_port: find_free_tcp_port().await?,
+            proposed_bridge_h2h_port: find_free_tcp_port().await?,
             gateway_h2h_port: find_free_tcp_port().await?,
             kex_done: false,
             commit_ada: self.config.toml.commit_ada,
@@ -133,14 +133,14 @@ impl HydrasManager {
     ) -> Result<(HydraController, KeyExchangeResponse)> {
         if initial.0
             != (KeyExchangeRequest {
-                accepted_platform_h2h_port: None,
+                accepted_bridge_h2h_port: None,
                 ..final_req.clone()
             })
         {
             bail!("The 2nd `KeyExchangeRequest` must be the same as the 1st one.")
         }
 
-        if final_req.accepted_platform_h2h_port != Some(initial.1.proposed_platform_h2h_port) {
+        if final_req.accepted_bridge_h2h_port != Some(initial.1.proposed_bridge_h2h_port) {
             bail!("The Bridge must accept the same port that was proposed to it.")
         }
 
@@ -157,7 +157,7 @@ impl HydrasManager {
             verifications::is_tcp_port_free(initial.1.gateway_h2h_port).await,
             Ok(true)
         ) && matches!(
-            verifications::is_tcp_port_free(initial.1.proposed_platform_h2h_port).await,
+            verifications::is_tcp_port_free(initial.1.proposed_bridge_h2h_port).await,
             Ok(true)
         )) {
             bail!(
@@ -263,9 +263,9 @@ impl std::error::Error for CreditError {}
 #[derive(serde::Deserialize, serde::Serialize, Debug, PartialEq, Eq, Clone)]
 pub struct KeyExchangeRequest {
     pub machine_id: MachineId,
-    pub platform_cardano_vkey: serde_json::Value,
-    pub platform_hydra_vkey: serde_json::Value,
-    pub accepted_platform_h2h_port: Option<u16>,
+    pub bridge_cardano_vkey: serde_json::Value,
+    pub bridge_hydra_vkey: serde_json::Value,
+    pub accepted_bridge_h2h_port: Option<u16>,
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, PartialEq, Clone)]
@@ -280,7 +280,7 @@ pub struct KeyExchangeResponse {
     /// since we’re tunneling through the WebSocket, and our hosts are
     /// both 127.0.0.1, the Gateway has to propose the port on the
     /// Bridge, too (as both sides open both ports).
-    pub proposed_platform_h2h_port: u16,
+    pub proposed_bridge_h2h_port: u16,
     pub gateway_h2h_port: u16,
     /// This being set to `true` means that the ceremony is successful, and the
     /// Gateway is going to start its own `hydra-node`, and the Bridge should too.
@@ -858,16 +858,16 @@ impl State {
             &self.kex_resp.protocol_parameters,
         )?;
 
-        let platform_hydra_vkey_path = self.config_dir.join("platform-hydra.vk");
+        let bridge_hydra_vkey_path = self.config_dir.join("bridge-hydra.vk");
         verifications::write_json_if_changed(
-            &platform_hydra_vkey_path,
-            &self.kex_req.platform_hydra_vkey,
+            &bridge_hydra_vkey_path,
+            &self.kex_req.bridge_hydra_vkey,
         )?;
 
-        let platform_cardano_vkey_path = self.config_dir.join("platform-payment.vk");
+        let bridge_cardano_vkey_path = self.config_dir.join("bridge-payment.vk");
         verifications::write_json_if_changed(
-            &platform_cardano_vkey_path,
-            &self.kex_req.platform_cardano_vkey,
+            &bridge_cardano_vkey_path,
+            &self.kex_req.bridge_cardano_vkey,
         )?;
 
         // Write the Blockfrost project ID to a file for hydra-node's --blockfrost option
@@ -903,14 +903,14 @@ impl State {
             .arg("--peer")
             .arg(format!(
                 "127.0.0.1:{}",
-                self.kex_resp.proposed_platform_h2h_port
+                self.kex_resp.proposed_bridge_h2h_port
             ))
             .arg("--monitoring-port")
             .arg(format!("{}", self.metrics_port))
             .arg("--hydra-verification-key")
-            .arg(platform_hydra_vkey_path)
+            .arg(bridge_hydra_vkey_path)
             .arg("--cardano-verification-key")
-            .arg(platform_cardano_vkey_path)
+            .arg(bridge_cardano_vkey_path)
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());

--- a/crates/gateway/src/sdk_bridge_ws.rs
+++ b/crates/gateway/src/sdk_bridge_ws.rs
@@ -173,7 +173,7 @@ pub mod event_loop {
 
                     let reply = match (
                         &state.hydras,
-                        &req.accepted_platform_h2h_port,
+                        &req.accepted_bridge_h2h_port,
                         initial_hydra_kex.is_some(),
                     ) {
                         (None, _, _) => GatewayMessage::Error {
@@ -203,7 +203,7 @@ pub mod event_loop {
                                                 tunnel_cancellation.clone(),
                                             );
 
-                                        tunnel_ctl.spawn_listener(resp.proposed_platform_h2h_port).await.expect("FIXME: this really shouldn’t fail, unless we hit the TOCTOU race condition…");
+                                        tunnel_ctl.spawn_listener(resp.proposed_bridge_h2h_port).await.expect("FIXME: this really shouldn’t fail, unless we hit the TOCTOU race condition…");
 
                                         let socket_tx_ = socket_tx.clone();
                                         tokio::spawn(async move {

--- a/crates/sdk_bridge/src/hydra_client/mod.rs
+++ b/crates/sdk_bridge/src/hydra_client/mod.rs
@@ -61,9 +61,9 @@ impl std::error::Error for CreditError {}
 #[derive(serde::Deserialize, serde::Serialize, Debug, PartialEq, Eq, Clone)]
 pub struct KeyExchangeRequest {
     pub machine_id: MachineId,
-    pub platform_cardano_vkey: serde_json::Value,
-    pub platform_hydra_vkey: serde_json::Value,
-    pub accepted_platform_h2h_port: Option<u16>,
+    pub bridge_cardano_vkey: serde_json::Value,
+    pub bridge_hydra_vkey: serde_json::Value,
+    pub accepted_bridge_h2h_port: Option<u16>,
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, PartialEq, Clone)]
@@ -78,7 +78,7 @@ pub struct KeyExchangeResponse {
     /// since we’re tunneling through the WebSocket, and our hosts are
     /// both 127.0.0.1, the Gateway has to propose the port on the
     /// Bridge, too (as both sides open both ports).
-    pub proposed_platform_h2h_port: u16,
+    pub proposed_bridge_h2h_port: u16,
     pub gateway_h2h_port: u16,
     /// This being set to `true` means that the ceremony is successful, and the
     /// Gateway is going to start its own `hydra-node`, and the Bridge should too.
@@ -178,7 +178,7 @@ struct State {
     /// Shared HTTP client for all outgoing requests.
     http: reqwest::Client,
     config_dir: PathBuf,
-    platform_cardano_vkey: serde_json::Value,
+    bridge_cardano_vkey: serde_json::Value,
     gateway_payment_addr: String,
     payment_params: Option<PaymentParams>,
     event_tx: mpsc::Sender<Event>,
@@ -237,7 +237,7 @@ impl State {
 
         let (event_tx, mut event_rx) = mpsc::channel::<Event>(32);
 
-        let platform_cardano_vkey =
+        let bridge_cardano_vkey =
             bf_common::cardano_keys::derive_vkey_from_skey(&config.cardano_signing_key)?;
 
         let blockfrost_api = blockfrost::BlockfrostAPI::new(
@@ -251,7 +251,7 @@ impl State {
             blockfrost_api: Some(blockfrost_api),
             http: reqwest::Client::new(),
             config_dir,
-            platform_cardano_vkey,
+            bridge_cardano_vkey,
             gateway_payment_addr: String::new(),
             payment_params: None,
             event_tx: event_tx.clone(),
@@ -392,11 +392,11 @@ impl State {
                 self.kex_requests
                     .send(KeyExchangeRequest {
                         machine_id: MachineId::of_this_host(),
-                        platform_cardano_vkey: self.platform_cardano_vkey.clone(),
-                        platform_hydra_vkey: verifications::read_json_file(
+                        bridge_cardano_vkey: self.bridge_cardano_vkey.clone(),
+                        bridge_hydra_vkey: verifications::read_json_file(
                             &self.config_dir.join("hydra.vk"),
                         )?,
-                        accepted_platform_h2h_port: None,
+                        accepted_bridge_h2h_port: None,
                     })
                     .await?;
 
@@ -452,7 +452,7 @@ impl State {
                     verifications::is_tcp_port_free(kex_resp.gateway_h2h_port).await,
                     Ok(true)
                 ) && matches!(
-                    verifications::is_tcp_port_free(kex_resp.proposed_platform_h2h_port).await,
+                    verifications::is_tcp_port_free(kex_resp.proposed_bridge_h2h_port).await,
                     Ok(true)
                 )) {
                     warn!("the ports proposed by the Gateway are not free locally, will ask again");
@@ -461,11 +461,11 @@ impl State {
                     self.kex_requests
                         .send(KeyExchangeRequest {
                             machine_id: MachineId::of_this_host(),
-                            platform_cardano_vkey: self.platform_cardano_vkey.clone(),
-                            platform_hydra_vkey: verifications::read_json_file(
+                            bridge_cardano_vkey: self.bridge_cardano_vkey.clone(),
+                            bridge_hydra_vkey: verifications::read_json_file(
                                 &self.config_dir.join("hydra.vk"),
                             )?,
-                            accepted_platform_h2h_port: Some(kex_resp.proposed_platform_h2h_port),
+                            accepted_bridge_h2h_port: Some(kex_resp.proposed_bridge_h2h_port),
                         })
                         .await?;
                 }
@@ -994,7 +994,7 @@ impl State {
             .arg("--listen")
             .arg(format!(
                 "127.0.0.1:{}",
-                kex_response.proposed_platform_h2h_port
+                kex_response.proposed_bridge_h2h_port
             ))
             .arg("--peer")
             .arg(format!("127.0.0.1:{}", kex_response.gateway_h2h_port))

--- a/crates/sdk_bridge/src/hydra_client/mod.rs
+++ b/crates/sdk_bridge/src/hydra_client/mod.rs
@@ -174,7 +174,7 @@ enum Event {
 struct State {
     config: HydraConfig,
     hydra_node_exe: String,
-    blockfrost_api: Option<blockfrost::BlockfrostAPI>,
+    blockfrost_api: blockfrost::BlockfrostAPI,
     /// Shared HTTP client for all outgoing requests.
     http: reqwest::Client,
     config_dir: PathBuf,
@@ -248,7 +248,7 @@ impl State {
         let mut self_ = Self {
             config,
             hydra_node_exe,
-            blockfrost_api: Some(blockfrost_api),
+            blockfrost_api,
             http: reqwest::Client::new(),
             config_dir,
             bridge_cardano_vkey,
@@ -353,12 +353,6 @@ impl State {
             #[cfg(not(unix))]
             let _ = pid;
         }
-    }
-
-    fn blockfrost_api(&self) -> Result<&blockfrost::BlockfrostAPI> {
-        self.blockfrost_api
-            .as_ref()
-            .ok_or_else(|| anyhow!("blockfrost API not initialized"))
     }
 
     async fn process_event(&mut self, event: Event) -> Result<()> {

--- a/crates/sdk_bridge/src/hydra_client/verifications.rs
+++ b/crates/sdk_bridge/src/hydra_client/verifications.rs
@@ -54,7 +54,7 @@ impl super::State {
     /// Check how much lovelace is available on an address (via Blockfrost).
     pub(super) async fn lovelace_on_addr(&self, address: &str) -> Result<u64> {
         let utxos = self
-            .blockfrost_api()?
+            .blockfrost_api
             .addresses_utxos(address, Pagination::all())
             .await;
 
@@ -117,7 +117,7 @@ impl super::State {
     /// hydra-node's `/commit` endpoint expects.
     pub(super) async fn query_utxo_json(&self, address: &str) -> Result<serde_json::Value> {
         let utxos = self
-            .blockfrost_api()?
+            .blockfrost_api
             .addresses_utxos(address, Pagination::all())
             .await;
 
@@ -205,7 +205,7 @@ impl super::State {
         use cardano_serialization_lib::CoinSelectionStrategyCIP2;
 
         let priv_key = cardano_keys::load_private_key(payment_skey_path)?;
-        let bf = self.blockfrost_api()?;
+        let bf = &self.blockfrost_api;
 
         // Fetch UTxOs via Blockfrost (limit to 200 to avoid MaxTxSizeUTxO)
         let utxos = bf.addresses_utxos(addr_from, Pagination::all()).await?;
@@ -262,7 +262,7 @@ impl super::State {
 
         // Submit via Blockfrost
         let tx_cbor = fixed_tx.to_bytes();
-        self.blockfrost_api()?
+        self.blockfrost_api
             .transactions_submit(tx_cbor.to_vec())
             .await?;
 
@@ -324,7 +324,7 @@ impl super::State {
         let signed_cbor = hex::decode(signed_cbor_hex)?;
 
         // Submit via Blockfrost.
-        self.blockfrost_api()?
+        self.blockfrost_api
             .transactions_submit(signed_cbor.to_vec())
             .await?;
 

--- a/crates/sdk_bridge/src/ws_client.rs
+++ b/crates/sdk_bridge/src/ws_client.rs
@@ -259,7 +259,7 @@ async fn run_ws_session(
                 if resp.machine_id != bf_common::hydra::MachineId::of_this_host() {
                     let (tunnel_ctl, mut tunnel_rx) = bf_common::tcp_mux_tunnel::Tunnel::new(
                         bf_common::tcp_mux_tunnel::TunnelConfig {
-                            expose_port: resp.proposed_platform_h2h_port,
+                            expose_port: resp.proposed_bridge_h2h_port,
                             id_prefix_bit: true,
                             ..(bf_common::tcp_mux_tunnel::TunnelConfig::default())
                         },


### PR DESCRIPTION
## Context

An omission…