### PR TITLE
Fix a few 1.0.0-rc.1 issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,6 +569,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tungstenite",
+ "url",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter", "fmt"] }
 tungstenite = "0.28.0"
 twelf = { version = "0.15.0", features = ["clap", "toml"] }
-url = "2"
+url = { version = "2", features = ["serde"] }
 uuid = { version = "1.10", features = ["serde", "v4"] }
 zip = "8.1.0"
 

--- a/crates/common/src/json_client.rs
+++ b/crates/common/src/json_client.rs
@@ -9,7 +9,7 @@ use crate::types::ApiResult;
 use axum::Json;
 use reqwest::{Client, Method, Url};
 use serde::de::DeserializeOwned;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 #[derive(Clone)]
 pub struct JsonClient {
@@ -40,7 +40,11 @@ impl JsonClient {
         let url_str = url.to_string();
         let resp = self.client.request(Method::GET, url).send().await?;
 
-        info!(path, url = %url_str, ?pagination, "JsonClient GET");
+        if path.is_empty() || path == "health" {
+            debug!(path, url = %url_str, ?pagination, "JsonClient GET");
+        } else {
+            info!(path, url = %url_str, ?pagination, "JsonClient GET");
+        }
 
         if resp.status() == 404 {
             warn!(

--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -37,6 +37,7 @@ dotenvy.workspace = true
 hex.workspace = true
 rand.workspace = true
 base64.workspace = true
+url.workspace = true
 uuid.workspace = true
 hyper.workspace = true
 tower.workspace = true

--- a/crates/gateway/config/development.toml
+++ b/crates/gateway/config/development.toml
@@ -1,7 +1,8 @@
 [server]
 address = '0.0.0.0:3001'
 log_level = 'info'
-url = 'https://api.domain.com'
+# If unset, we fall back to the `Host:` header
+#url = 'http://127.0.0.1:3001'
 
 [database]
 connection_string = 'postgresql://user:pass@host:port/db'

--- a/crates/gateway/src/api/register.rs
+++ b/crates/gateway/src/api/register.rs
@@ -78,14 +78,29 @@ pub async fn route(
         ));
     }
 
-    // How the client sees us, needed for the load balancing experiment:
-    let our_host: String = headers
-        .get("Host")
-        .and_then(|a| a.to_str().ok())
-        .ok_or(APIError::Validation(
-            "The request didn't set the Host: header field.".to_string(), // unreachable in HTTP ≥ 1.1
-        ))?
-        .to_string();
+    // WebSocket URI for the load balancing experiment.
+    // When `server.url` is configured we map http(s) to ws(s) so the
+    // platform receives a fully qualified URI. Otherwise fall back to a
+    // protocol-relative URI derived from the Host header.
+    let ws_uri: String = if let Some(ref url) = config.server.url {
+        let base = if let Some(rest) = url.strip_prefix("https://") {
+            format!("wss://{}", rest.trim_end_matches('/'))
+        } else if let Some(rest) = url.strip_prefix("http://") {
+            format!("ws://{}", rest.trim_end_matches('/'))
+        } else {
+            unreachable!("server.url scheme is validated at config load time")
+        };
+        format!("{base}/ws")
+    } else {
+        let host =
+            headers
+                .get("Host")
+                .and_then(|a| a.to_str().ok())
+                .ok_or(APIError::Validation(
+                    "The request didn't set the Host: header field.".to_string(), // unreachable in HTTP ≥ 1.1
+                ))?;
+        format!("//{host}/ws")
+    };
 
     // check if user has correct secret
     let authorized_user = db.authorize_user(payload.secret).await?;
@@ -183,8 +198,7 @@ pub async fn route(
         status: "registered".to_string(),
         route: payload.api_prefix,
         load_balancers: vec![LoadBalancer {
-            // We can’t know if it’s HTTPS or HTTP here, so we have to count on `blockfrost-platform`:
-            uri: format!("//{our_host}/ws"),
+            uri: ws_uri,
             access_token: token,
         }],
     };

--- a/crates/gateway/src/api/register.rs
+++ b/crates/gateway/src/api/register.rs
@@ -82,22 +82,27 @@ pub async fn route(
     // When `server.url` is configured we map http(s) to ws(s) so the
     // platform receives a fully qualified URI. Otherwise fall back to a
     // protocol-relative URI derived from the Host header.
-    let ws_uri: String = if let Some(ref url) = config.server.url {
-        let base = if let Some(rest) = url.strip_prefix("https://") {
-            format!("wss://{}", rest.trim_end_matches('/'))
-        } else if let Some(rest) = url.strip_prefix("http://") {
-            format!("ws://{}", rest.trim_end_matches('/'))
+    let ws_uri: String = if let Some(url) = config.server.url.clone() {
+        let mut ws_url = url;
+        let ws_scheme = if ws_url.scheme() == "https" {
+            "wss"
         } else {
-            unreachable!("server.url scheme is validated at config load time")
+            "ws"
         };
-        format!("{base}/ws")
+        ws_url
+            .set_scheme(ws_scheme)
+            .expect("ws(s) is a valid scheme transition from http(s)");
+        ws_url.set_path("/ws");
+        ws_url.set_query(None);
+        ws_url.set_fragment(None);
+        ws_url.into()
     } else {
         let host =
             headers
                 .get("Host")
                 .and_then(|a| a.to_str().ok())
                 .ok_or(APIError::Validation(
-                    "The request didn't set the Host: header field.".to_string(), // unreachable in HTTP ≥ 1.1
+                    "The request didn't set the Host: header field.".to_string(), // unreachable in HTTP >= 1.1
                 ))?;
         format!("//{host}/ws")
     };

--- a/crates/gateway/src/api/root.rs
+++ b/crates/gateway/src/api/root.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 
 #[derive(Serialize)]
 pub struct Response {
-    pub url: Option<String>,
+    pub url: Option<url::Url>,
     pub version: String,
     pub healthy: bool,
     pub commit: &'static str,

--- a/crates/gateway/src/config.rs
+++ b/crates/gateway/src/config.rs
@@ -150,7 +150,16 @@ pub fn load_config(path: PathBuf) -> Config {
         hydra_bridge: toml_config.hydra_bridge,
     };
 
-    override_with_env(config)
+    let config = override_with_env(config);
+
+    if let Some(ref url) = config.server.url {
+        assert!(
+            url.starts_with("http://") || url.starts_with("https://"),
+            "server.url must start with http:// or https://, got: {url}"
+        );
+    }
+
+    config
 }
 
 fn network_from_project_id(project_id: &str) -> Result<Network> {

--- a/crates/gateway/src/config.rs
+++ b/crates/gateway/src/config.rs
@@ -22,7 +22,7 @@ pub struct Args {
 pub struct ServerInput {
     pub address: String,
     pub log_level: String,
-    pub url: Option<String>,
+    pub url: Option<url::Url>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -52,7 +52,7 @@ pub struct Server {
     #[serde(deserialize_with = "deserialize_log_level")]
     pub log_level: Level,
     pub network: Network,
-    pub url: Option<String>,
+    pub url: Option<url::Url>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -139,7 +139,7 @@ pub fn load_config(path: PathBuf) -> Config {
             address: toml_config.server.address,
             log_level,
             network,
-            url: toml_config.server.url,
+            url: toml_config.server.url.inspect(validate_server_url),
         },
         database: Db { connection_string },
         blockfrost: Blockfrost {
@@ -150,16 +150,29 @@ pub fn load_config(path: PathBuf) -> Config {
         hydra_bridge: toml_config.hydra_bridge,
     };
 
-    let config = override_with_env(config);
+    override_with_env(config)
+}
 
-    if let Some(ref url) = config.server.url {
-        assert!(
-            url.starts_with("http://") || url.starts_with("https://"),
-            "server.url must start with http:// or https://, got: {url}"
-        );
+/// Validate that a parsed `server.url` uses http(s) and includes a host.
+/// Panics on violation so that misconfiguration is caught at startup.
+fn validate_server_url(url: &url::Url) {
+    match url.scheme() {
+        "http" | "https" => {},
+        other => panic!("server.url must use http:// or https://, got: {other}://"),
     }
+    assert!(
+        url.host().is_some(),
+        "server.url must include a host, got: {url}"
+    );
+}
 
-    config
+/// Parse a raw string into a [`url::Url`] and validate it.
+/// Used for the `SERVER_URL` environment variable override.
+fn parse_server_url(raw: &str) -> url::Url {
+    let parsed = url::Url::parse(raw)
+        .unwrap_or_else(|e| panic!("SERVER_URL is not a valid URL ({raw}): {e}"));
+    validate_server_url(&parsed);
+    parsed
 }
 
 fn network_from_project_id(project_id: &str) -> Result<Network> {
@@ -175,7 +188,10 @@ fn network_from_project_id(project_id: &str) -> Result<Network> {
 }
 
 fn override_with_env(config: Config) -> Config {
-    let server_url = var("SERVER_URL").ok().or(config.server.url.clone());
+    let server_url = var("SERVER_URL")
+        .ok()
+        .map(|s| parse_server_url(&s))
+        .or(config.server.url);
     let server_address = var("SERVER_ADDRESS").unwrap_or(config.server.address);
     let log_level_str =
         var("SERVER_LOG_LEVEL").unwrap_or_else(|_| config.server.log_level.to_string());

--- a/crates/platform/src/icebreakers/api.rs
+++ b/crates/platform/src/icebreakers/api.rs
@@ -53,8 +53,16 @@ impl IcebreakersAPI {
                     .clone()
                     .unwrap_or_else(|| config.network.default_gateway_url().to_string());
 
-                let client = Client::builder()
-                    .local_address(config.server_address)
+                let mut builder = Client::builder();
+
+                // Only bind outgoing requests to a specific local address when
+                // it's a real routable interface IP. EINVAL otherwise.
+                let addr = config.server_address;
+                if !addr.is_loopback() && !addr.is_unspecified() {
+                    builder = builder.local_address(addr);
+                }
+
+                let client = builder
                     .build()
                     .map_err(|e| AppError::Registration(format!("Registering failed: {e}")))?;
                 let icebreakers_api = IcebreakersAPI {


### PR DESCRIPTION
## Context

PR to `main`, because they're also there. Let's keep the release PR small. I'll merge `main` to it after this.

- 2a041aa fix(platform): bind outgoing requests only to real routable IPs
- d66c1de fix(gateway): derive load balancer WebSocket URI from configured `server.url`
- 537361b fix(data-node): reduce log level for health-check requests