### PR TITLE
fix(node): log tx submission failures as warnings

### DIFF
--- a/crates/node/src/cbor/validation.rs
+++ b/crates/node/src/cbor/validation.rs
@@ -1,7 +1,7 @@
 use bf_common::errors::BlockfrostError;
 use pallas_hardano::display::haskell_error::as_cbor_decode_failure;
 use pallas_primitives::{alonzo::Value, babbage::GenTransactionOutput, conway::Tx};
-use tracing::info;
+use tracing::warn;
 
 /// Checks if the given transaction is a valid CBOR-encoded transaction, by trying to decode it.
 /// This function is used to validate the transaction before submitting it to the node.
@@ -20,7 +20,7 @@ pub(crate) fn validate_tx_cbor(tx: &[u8]) -> Result<(), BlockfrostError> {
             }
         },
         Err(e) => {
-            info!("Invalid TX CBOR: {:?}, CBOR: {}", e, hex::encode(tx));
+            warn!("Invalid TX CBOR: {:?}, CBOR: {}", e, hex::encode(tx));
             Err(BlockfrostError::custom_400(
                 as_cbor_decode_failure(e.to_string(), e.position().unwrap_or(0) as u64)
                     .unwrap_or_else(|e| format!("Failed to format decode error: {e}")),

--- a/crates/node/src/transactions.rs
+++ b/crates/node/src/transactions.rs
@@ -7,7 +7,7 @@ use pallas_network::miniprotocols::{
     localstate,
     localtxsubmission::{EraTx, Response},
 };
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 impl NodeClient {
     /// Submits a transaction to the connected Cardano node.
@@ -46,7 +46,7 @@ impl NodeClient {
             Ok(Response::Rejected(reason)) => {
                 let haskell_display = as_node_submit_error(reason)
                     .unwrap_or_else(|e| format!("Failed to format submit error: {e}"));
-                info!(
+                warn!(
                     connection_id = self.connection_id,
                     "TxSubmitFail: {}, CBOR: {}",
                     haskell_display,


### PR DESCRIPTION
## Context

This looks better in `journal`, IMO. Previously, we logged `http/400` as a yellow `tracing::warn!`, but its reason – the actual tx submit failure – as a white `tracing::info!`, which feels a little inconsistent.

See this – IMO wrong – example of what's happening without this PR:

<img alt="Screenshot-20260421-173434" src="https://github.com/user-attachments/assets/30a1c9d8-1490-4c7e-99a9-ed57ac5dc055" />
