### PR TITLE
chore: release 1.0.0-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,19 @@
-## [1.0.0-rc.1] - 2026-04-xx
+## [1.0.0-rc.2] - 2026-04-28
+
+### Added
+
+- Gateway high-availability: advertise multiple peer URLs during registration, new `/any/*` round-robin route across all connected Platforms
+- Tracing: `journal` and `syslog` log targets via `*_LOG_TARGET` environment variables
+
+### Changed
+
+- Gateway environment variable overrides now require a `BLOCKFROST_GATEWAY` prefix
+
+### Fixed
+
+- Tx submission failures logged as warnings instead of errors
+
+## [1.0.0-rc.1] - 2026-04-21
 
 ### Highlights
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,7 +540,7 @@ dependencies = [
 
 [[package]]
 name = "blockfrost-gateway"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -595,7 +595,7 @@ dependencies = [
 
 [[package]]
 name = "blockfrost-platform"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -645,14 +645,14 @@ dependencies = [
 
 [[package]]
 name = "blockfrost-platform-api-provider"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "blockfrost-openapi",
 ]
 
 [[package]]
 name = "blockfrost-platform-build-utils"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "bzip2",
  "reqwest 0.13.2",
@@ -662,7 +662,7 @@ dependencies = [
 
 [[package]]
 name = "blockfrost-platform-common"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -695,7 +695,7 @@ dependencies = [
 
 [[package]]
 name = "blockfrost-platform-data-node"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "axum",
  "blockfrost-platform-api-provider",
@@ -708,7 +708,7 @@ dependencies = [
 
 [[package]]
 name = "blockfrost-platform-integration-tests"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "blockfrost-platform-node"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "blockfrost-platform-build-utils",
  "blockfrost-platform-common",
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "blockfrost-sdk-bridge"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 license = "Apache-2.0"
 edition = "2024"
 

--- a/docs/src/content/icebreakers.mdx
+++ b/docs/src/content/icebreakers.mdx
@@ -165,8 +165,8 @@ Currently, this new WebSocket endpoint is served by the same IceBreakers API dur
    ```json
    {
      "name": "blockfrost-platform",
-     "version": "1.0.0-rc.1",
-     "revision": "3e0d83224cad291306c2b07b9ae0ac9a2564dd6a",
+     "version": "1.0.0-rc.2",
+     "revision": "0000000000000000000000000000000000000000",
      "healthy": true,
      "node_info": {
        "block": "6d87f87a0642fd4a59bb8af89400e8c7a777e290d2c2e02ceb93059ac7b4aaba",

--- a/docs/src/content/icebreakers.mdx
+++ b/docs/src/content/icebreakers.mdx
@@ -166,7 +166,7 @@ Currently, this new WebSocket endpoint is served by the same IceBreakers API dur
    {
      "name": "blockfrost-platform",
      "version": "1.0.0-rc.2",
-     "revision": "0000000000000000000000000000000000000000",
+     "revision": "fb6cbb6a21b3351e0d35a25190bc5f911b6edb28",
      "healthy": true,
      "node_info": {
        "block": "6d87f87a0642fd4a59bb8af89400e8c7a777e290d2c2e02ceb93059ac7b4aaba",

--- a/docs/src/content/installation/nix.md
+++ b/docs/src/content/installation/nix.md
@@ -23,5 +23,5 @@ Then you can move on to [Configuring the platform](/configuration).
 
 ```bash
 $ ./result/bin/blockfrost-platform --version
-blockfrost-platform 1.0.0-rc.1 (<3e0d83224cad291306c2b07b9ae0ac9a2564dd6a>)
+blockfrost-platform 1.0.0-rc.2 (<0000000000000000000000000000000000000000>)
 ```

--- a/docs/src/content/installation/nix.md
+++ b/docs/src/content/installation/nix.md
@@ -23,5 +23,5 @@ Then you can move on to [Configuring the platform](/configuration).
 
 ```bash
 $ ./result/bin/blockfrost-platform --version
-blockfrost-platform 1.0.0-rc.2 (<0000000000000000000000000000000000000000>)
+blockfrost-platform 1.0.0-rc.2 (<fb6cbb6a21b3351e0d35a25190bc5f911b6edb28>)
 ```

--- a/docs/src/content/installation/source.mdx
+++ b/docs/src/content/installation/source.mdx
@@ -44,5 +44,5 @@ cargo build --release
 
 # Run the binary
 ./target/release/blockfrost-platform  --version
-blockfrost-platform 1.0.0-rc.2 (<0000000000000000000000000000000000000000>)
+blockfrost-platform 1.0.0-rc.2 (<fb6cbb6a21b3351e0d35a25190bc5f911b6edb28>)
 ```

--- a/docs/src/content/installation/source.mdx
+++ b/docs/src/content/installation/source.mdx
@@ -44,5 +44,5 @@ cargo build --release
 
 # Run the binary
 ./target/release/blockfrost-platform  --version
-blockfrost-platform 1.0.0-rc.1 (<3e0d83224cad291306c2b07b9ae0ac9a2564dd6a>)
+blockfrost-platform 1.0.0-rc.2 (<0000000000000000000000000000000000000000>)
 ```


### PR DESCRIPTION
## Context

The release commit tagged as `1.0.0-rc.2` is fb6cbb6a21b3351e0d35a25190bc5f911b6edb28.