### PR TITLE
chore: drop `x86_64-darwin` support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,16 +38,13 @@ jobs:
           $nixdl  result-archive-x86_64-linux      "$ref"#internal.x86_64-linux.archive
           $nixdl  result-archive-aarch64-linux     "$ref"#internal.aarch64-linux.archive
           $nixdl  result-archive-x86_64-windows    "$ref"#internal.x86_64-windows.archive
-          $nixdl  result-archive-x86_64-darwin     "$ref"#internal.x86_64-darwin.archive
           $nixdl  result-archive-aarch64-darwin    "$ref"#internal.aarch64-darwin.archive
 
           $nixdl  result-installer-x86_64-windows  "$ref"#internal.x86_64-windows.installer
-          $nixdl  result-installer-x86_64-darwin   "$ref"#internal.x86_64-darwin.installer
           $nixdl  result-installer-aarch64-darwin  "$ref"#internal.aarch64-darwin.installer
 
           $nixdl  result-archive-bridge-x86_64-linux      "$ref"#internal.x86_64-linux.archive-bridge
           $nixdl  result-archive-bridge-aarch64-linux     "$ref"#internal.aarch64-linux.archive-bridge
-          $nixdl  result-archive-bridge-x86_64-darwin     "$ref"#internal.x86_64-darwin.archive-bridge
           $nixdl  result-archive-bridge-aarch64-darwin    "$ref"#internal.aarch64-darwin.archive-bridge
 
           $nixdl  result-homebrew-tap              "$ref"#internal.aarch64-darwin.homebrew-tap
@@ -61,15 +58,12 @@ jobs:
           files: |
             result-archive-x86_64-linux/*.tar.bz2
             result-archive-aarch64-linux/*.tar.bz2
-            result-archive-x86_64-darwin/*.tar.bz2
             result-archive-x86_64-windows/*.zip
             result-archive-aarch64-darwin/*.tar.bz2
             result-installer-x86_64-windows/*.exe
-            result-installer-x86_64-darwin/*.dmg
             result-installer-aarch64-darwin/*.dmg
             result-archive-bridge-x86_64-linux/*.tar.bz2
             result-archive-bridge-aarch64-linux/*.tar.bz2
-            result-archive-bridge-x86_64-darwin/*.tar.bz2
             result-archive-bridge-aarch64-darwin/*.tar.bz2
             result-curl-bash-install/*.sh
 

--- a/flake.nix
+++ b/flake.nix
@@ -67,7 +67,6 @@
         "x86_64-linux"
         "aarch64-linux"
         "aarch64-darwin"
-        "x86_64-darwin"
       ];
       perSystem = {
         system,
@@ -112,7 +111,7 @@
             rustfmt.package = internal.rustPackages.rustfmt;
             shfmt.enable = true;
             taplo.enable = true; # TOML
-            yamlfmt.enable = pkgs.stdenv.hostPlatform.system != "x86_64-darwin"; # a treefmt-nix+yamlfmt bug on Intel Macs
+            yamlfmt.enable = true;
             yamllint.enable = true;
           };
           settings.global.excludes = [
@@ -193,7 +192,6 @@
             );
             installer = {
               x86_64-windows = inputs.self.internal.x86_64-windows.installer;
-              x86_64-darwin = inputs.self.internal.x86_64-darwin.installer;
               aarch64-darwin = inputs.self.internal.aarch64-darwin.installer;
             };
             homebrew-tap = {

--- a/flake.nix
+++ b/flake.nix
@@ -101,7 +101,7 @@
             '';
           };
 
-        treefmt = {pkgs, ...}: {
+        treefmt = {
           projectRootFile = "flake.nix";
           programs = {
             alejandra.enable = true; # Nix

--- a/nix/internal/curl-bash-install.sh
+++ b/nix/internal/curl-bash-install.sh
@@ -20,10 +20,6 @@ case "${isa}-${kernel}" in
   target_system="aarch64-linux"
   expected_sha256="@sha256_aarch64_linux@"
   ;;
-"x86_64-Darwin")
-  target_system="x86_64-darwin"
-  expected_sha256="@sha256_x86_64_darwin@"
-  ;;
 # Apple Silicon can appear as "arm64-Darwin" rather than "aarch64-Darwin":
 "arm64-Darwin")
   target_system="aarch64-darwin"

--- a/nix/internal/darwin.nix
+++ b/nix/internal/darwin.nix
@@ -3,7 +3,7 @@
   targetSystem,
   unix,
 }:
-assert builtins.elem targetSystem ["x86_64-darwin" "aarch64-darwin"]; let
+assert builtins.elem targetSystem ["aarch64-darwin"]; let
   buildSystem = targetSystem;
   pkgs = inputs.nixpkgs.legacyPackages.${buildSystem};
   inherit (pkgs) lib;
@@ -110,14 +110,11 @@ in
     homebrew-tap =
       pkgs.runCommand "homebrew-repo" {
         inherit (unix.blockfrost-platform) version;
-        url_x86_64 = "${unix.releaseBaseUrl}/${inputs.self.internal.x86_64-darwin.archive.outFileName}";
         url_aarch64 = "${unix.releaseBaseUrl}/${inputs.self.internal.aarch64-darwin.archive.outFileName}";
       } ''
         cp -r ${./homebrew-tap} $out
         chmod -R +w $out
 
-        sha256_x86_64=$(sha256sum ${inputs.self.internal.x86_64-darwin.archive}/*.tar.bz2 | cut -d' ' -f1)
-        export sha256_x86_64
         sha256_aarch64=$(sha256sum ${inputs.self.internal.aarch64-darwin.archive}/*.tar.bz2 | cut -d' ' -f1)
         export sha256_aarch64
 

--- a/nix/internal/homebrew-tap/Formula/blockfrost-platform.rb
+++ b/nix/internal/homebrew-tap/Formula/blockfrost-platform.rb
@@ -4,15 +4,10 @@ class BlockfrostPlatform < Formula
   license "Apache-2.0"
   version "@version@"
 
-  if OS.mac?
-    if Hardware::CPU.intel?
-      url "@url_x86_64@"
-      sha256 "@sha256_x86_64@"
-    else
-      url "@url_aarch64@"
-      sha256 "@sha256_aarch64@"
-    end
-  end
+  depends_on arch: :arm64
+
+  url "@url_aarch64@"
+  sha256 "@sha256_aarch64@"
 
   def install
     bin.install Dir["bin/*"]

--- a/nix/internal/unix.nix
+++ b/nix/internal/unix.nix
@@ -3,7 +3,7 @@
   targetSystem,
 }:
 # For now, let's keep all UNIX definitions together, until they diverge more in the future.
-assert builtins.elem targetSystem ["x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin"]; let
+assert builtins.elem targetSystem ["x86_64-linux" "aarch64-linux" "aarch64-darwin"]; let
   buildSystem = targetSystem;
   pkgs = inputs.nixpkgs.legacyPackages.${buildSystem};
   inherit (pkgs) lib;
@@ -328,7 +328,7 @@ in
     cardano-node-packages =
       {
         x86_64-linux = cardano-node-flake.hydraJobs.x86_64-linux.musl;
-        inherit (cardano-node-flake.packages) x86_64-darwin aarch64-darwin aarch64-linux;
+        inherit (cardano-node-flake.packages) aarch64-darwin aarch64-linux;
       }.${
         targetSystem
       };
@@ -410,7 +410,6 @@ in
           url =
             {
               "x86_64-linux" = "${baseUrl}-${release}-linux64.tar.gz";
-              "x86_64-darwin" = "${baseUrl}-${release}-macos-intel.tar.gz";
               "aarch64-darwin" = "${baseUrl}-${release}-macos-silicon.tar.gz";
             }.${
               targetSystem
@@ -418,7 +417,6 @@ in
           hash =
             {
               "x86_64-linux" = "sha256-EOe6ooqvSGylJMJnWbqDrUIVYzwTCw5Up/vU/gPK6tE=";
-              "x86_64-darwin" = "sha256-POUj3Loo8o7lBI4CniaA/Z9mTRAmWv9VWAdtcIMe27I=";
               "aarch64-darwin" = "sha256-+6bzdUXnJ+nnYdZuhLueT0+bYmXzwDXTe9JqWrWnfe4=";
             }.${
               targetSystem
@@ -475,12 +473,10 @@ in
       } ''
         sha256_x86_64_linux=$(sha256sum ${inputs.self.hydraJobs.archive.x86_64-linux}/*.tar.* | cut -d' ' -f1)
         sha256_aarch64_linux=$(sha256sum ${inputs.self.hydraJobs.archive.aarch64-linux}/*.tar.* | cut -d' ' -f1)
-        sha256_x86_64_darwin=$(sha256sum ${inputs.self.hydraJobs.archive.x86_64-darwin}/*.tar.* | cut -d' ' -f1)
         sha256_aarch64_darwin=$(sha256sum ${inputs.self.hydraJobs.archive.aarch64-darwin}/*.tar.* | cut -d' ' -f1)
 
         export sha256_x86_64_linux
         export sha256_aarch64_linux
-        export sha256_x86_64_darwin
         export sha256_aarch64_darwin
 
         mkdir -p $out


### PR DESCRIPTION
## Context

Approved by @mmahut [on Slack](https://input-output-rnd.slack.com/archives/C07FD0DNEMQ/p1778241133251339).

Apple stopped shipping Intel Macs in 2023 and Homebrew has dropped official support. Remove `x86_64-darwin` from the flake systems list, release workflow, curl-bash installer, Homebrew formula, and all Nix derivations that referenced Intel macOS archives or hashes.