### PR TITLE
chore: downgrade `blockfrost-tests` to make the CI green

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -19,11 +19,11 @@
     "blockfrost-tests": {
       "flake": false,
       "locked": {
-        "lastModified": 1778850823,
-        "narHash": "sha256-XKTHoJjmTkw1AN1mSky82TQvBN6qGMP3vLkPCn+8rS4=",
+        "lastModified": 1778849007,
+        "narHash": "sha256-G+G7+oyCop8lAYsfI7hddPbOSVc7gguXQvIVcQOoNPA=",
         "owner": "blockfrost",
         "repo": "blockfrost-tests",
-        "rev": "7c8dfa875c1971033d76abe548c32736542193a6",
+        "rev": "dac734c1e6c96e85b087995735665b27313d356e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Resolves #475

## Context

Originally caused by the updates in:
- https://github.com/blockfrost/blockfrost-tests/pull/83 – perhaps we should use `oneOf` there?

I will also make the Dolos tests required on CI, because this wrong merge to main was caused by me enabling auto-merge in:
- #569

A fix:
- https://github.com/blockfrost/blockfrost-tests/pull/85

### Example failure

https://github.com/blockfrost/blockfrost-platform/actions/runs/26091034851/job/76716505681:

```
FAIL  src/tests/preview/routes.ts > Integration Tests - preview > pools endpoints > [pools/:pool_id/metadata - CONNECTION_ERROR - only basic pool metadata info returned] - pools/pool1clnnqvd5t8y9gnsqd229glt5ag4mljz3q74y3v5lxcnk2ye056s/metadata
 FAIL  src/tests/preview/routes.ts > Integration Tests - preview > pools endpoints > [pools/:pool_id/metadata - CONNECTION_ERROR - only basic pool metadata info returned] - pools/c7e73031b459c8544e006a94547d74ea2bbfc85107aa48b29f362765/metadata
AssertionError: expected { pool_id: 'pool1clnnqvd5t8y9gnsqd229glt5ag4mljz3q74y3v5lxcnk2ye056s', hex: 'c7e73031b459c8544e006a94547d74ea2bbfc85107aa48b29f362765', url: 'http://localhost:23009/p/pool_clai_registration_metadata.json', hash: '9a72e6da5f7402ace105ea1232c4fbc9b14cd9d54998557c0ccaf0aa03c8e2f9', error: { code: 'CONNECTION_ERROR', message: 'Error Offchain Pool: Connection failure error when fetching metadata from http://localhost:23009/p/pool_clai_registration_metadata.json.' }, ticker: null, name: null, description: null, homepage: null } to strictly equal { pool_id: 'pool1clnnqvd5t8y9gnsqd229glt5ag4mljz3q74y3v5lxcnk2ye056s', hex: 'c7e73031b459c8544e006a94547d74ea2bbfc85107aa48b29f362765', url: Any<String>, hash: Any<String>, ticker: null, name: null, description: null, homepage: null, error: { code: 'CONNECTION_ERROR', message: 'Error Offchain Pool: URL parse error for http://localhost:23009/p/pool_clai_registration_metadata.json resulted in : "Access to localhost is not allowed"' } }
```

```diff
- Expected
+ Received

@@ -1,10 +1,10 @@
  {
    "description": null,
    "error": {
      "code": "CONNECTION_ERROR",
-     "message": "Error Offchain Pool: URL parse error for http://localhost:23009/p/pool_clai_registration_metadata.json resulted in : \"Access to localhost is not allowed\"",
+     "message": "Error Offchain Pool: Connection failure error when fetching metadata from http://localhost:23009/p/pool_clai_registration_metadata.json.",
    },
    "hash": Any<String>,
    "hex": "c7e73031b459c8544e006a94547d74ea2bbfc85107aa48b29f362765",
    "homepage": null,
    "name": null,
```