### PR TITLE
fix(platform): restore `local_address` bind for unspecified IPs (IPv6 regression)

### DIFF
--- a/crates/platform/src/icebreakers/api.rs
+++ b/crates/platform/src/icebreakers/api.rs
@@ -56,10 +56,12 @@ impl IcebreakersAPI {
 
                 let mut builder = Client::builder();
 
-                // Only bind outgoing requests to a specific local address when
-                // it's a real routable interface IP. EINVAL otherwise.
+                // Bind outgoing requests to the configured local address so
+                // that the IP family matches the server socket (e.g. 0.0.0.0
+                // forces an IPv4 socket, avoiding AAAA resolution). Skip only
+                // loopback, which can't route to external servers.
                 let addr = config.server_address;
-                if !addr.is_loopback() && !addr.is_unspecified() {
+                if !addr.is_loopback() {
                     builder = builder.local_address(addr);
                 }
 


### PR DESCRIPTION
## Context

Commit 2a041aa884e34c9a39d4145bbbbe919a01d01603 skipped the `local_address()` bind for unspecified addresses like 0.0.0.0, breaking the IPv4-forcing behavior from PR #232.

Users on dual-stack systems saw `reqwest` resolve the `AAAA` record for icebreakers-mainnet.blockfrost.io and connect over IPv6, which fails. Keep only the loopback guard, since binding to 0.0.0.0 is valid and forces an IPv4 socket, which is the intended effect of `--server-address 0.0.0.0`.

Reported-By: @SmaugPool