### PR TITLE
feat: support more `minibf` endpoints of Dolos

### DIFF
--- a/crates/api_provider/src/types.rs
+++ b/crates/api_provider/src/types.rs
@@ -31,7 +31,7 @@ use blockfrost_openapi::models::{
     proposal_parameters_parameters::ProposalParametersParameters,
     proposal_votes_inner::ProposalVotesInner, proposal_withdrawals_inner::ProposalWithdrawalsInner,
     proposals_inner::ProposalsInner, script::Script, script_cbor::ScriptCbor,
-    script_datum_cbor::ScriptDatumCbor, script_json::ScriptJson,
+    script_datum::ScriptDatum, script_datum_cbor::ScriptDatumCbor, script_json::ScriptJson,
     script_redeemers_inner::ScriptRedeemersInner, scripts_inner::ScriptsInner,
     tx_content::TxContent, tx_content_cbor::TxContentCbor,
     tx_content_delegations_inner::TxContentDelegationsInner,
@@ -117,10 +117,11 @@ pub type MetadataLabelCborResponse = Vec<TxMetadataLabelCborInner>;
 
 // scripts
 pub type ScriptsSingleResponse = Script;
-pub type ScriptsDatumCborResponse = Vec<ScriptDatumCbor>;
+pub type ScriptsDatumResponse = ScriptDatum;
+pub type ScriptsDatumCborResponse = ScriptDatumCbor;
 pub type ScriptsInnerResponse = Vec<ScriptsInner>;
-pub type ScriptsCborResponse = Vec<ScriptCbor>;
-pub type ScriptsJsonResponse = Vec<ScriptJson>;
+pub type ScriptsCborResponse = ScriptCbor;
+pub type ScriptsJsonResponse = ScriptJson;
 pub type ScriptsRedeemersInnerResponse = Vec<ScriptRedeemersInner>;
 
 // pools

--- a/crates/data_node/src/api.rs
+++ b/crates/data_node/src/api.rs
@@ -10,4 +10,5 @@ pub mod metadata;
 pub mod network;
 pub mod pools;
 pub mod root;
+pub mod scripts;
 pub mod txs;

--- a/crates/data_node/src/api/addresses.rs
+++ b/crates/data_node/src/api/addresses.rs
@@ -52,4 +52,10 @@ impl DataNodeAddresses<'_> {
 
         self.inner.client.get(&path, Some(pagination)).await
     }
+
+    pub async fn txs(&self, address: &str, pagination: &Pagination) -> ApiResult<Vec<String>> {
+        let path = format!("addresses/{address}/txs");
+
+        self.inner.client.get(&path, Some(pagination)).await
+    }
 }

--- a/crates/data_node/src/api/assets.rs
+++ b/crates/data_node/src/api/assets.rs
@@ -1,6 +1,8 @@
 use crate::client::DataNode;
-use bf_api_provider::types::AssetsSingleResponse;
-use bf_common::types::ApiResult;
+use bf_api_provider::types::{
+    AssetsAddressesResponse, AssetsSingleResponse, AssetsTransactionsResponse,
+};
+use bf_common::{pagination::Pagination, types::ApiResult};
 
 pub struct DataNodeAssets<'a> {
     pub(crate) inner: &'a DataNode,
@@ -17,5 +19,25 @@ impl DataNodeAssets<'_> {
         let path = format!("assets/{asset_id}");
 
         self.inner.client.get(&path, None).await
+    }
+
+    pub async fn addresses(
+        &self,
+        asset_id: &str,
+        pagination: &Pagination,
+    ) -> ApiResult<AssetsAddressesResponse> {
+        let path = format!("assets/{asset_id}/addresses");
+
+        self.inner.client.get(&path, Some(pagination)).await
+    }
+
+    pub async fn transactions(
+        &self,
+        asset_id: &str,
+        pagination: &Pagination,
+    ) -> ApiResult<AssetsTransactionsResponse> {
+        let path = format!("assets/{asset_id}/transactions");
+
+        self.inner.client.get(&path, Some(pagination)).await
     }
 }

--- a/crates/data_node/src/api/epochs.rs
+++ b/crates/data_node/src/api/epochs.rs
@@ -1,6 +1,6 @@
 use crate::client::DataNode;
 use bf_api_provider::types::EpochsParamResponse;
-use bf_common::types::ApiResult;
+use bf_common::{pagination::Pagination, types::ApiResult};
 
 pub struct DataNodeEpochs<'a> {
     pub(crate) inner: &'a DataNode,
@@ -24,5 +24,11 @@ impl DataNodeEpochs<'_> {
             .client
             .get("epochs/latest/parameters", None)
             .await
+    }
+
+    pub async fn blocks(&self, number: &i32, pagination: &Pagination) -> ApiResult<Vec<String>> {
+        let path = format!("epochs/{number}/blocks");
+
+        self.inner.client.get(&path, Some(pagination)).await
     }
 }

--- a/crates/data_node/src/api/pools.rs
+++ b/crates/data_node/src/api/pools.rs
@@ -1,6 +1,7 @@
 use crate::client::DataNode;
 use bf_api_provider::types::{
-    PoolsDelegatorsResponse, PoolsListExtendedResponse, PoolsMetadataResponse, PoolsSingleResponse,
+    PoolsDelegatorsResponse, PoolsHistoryResponse, PoolsListExtendedResponse,
+    PoolsMetadataResponse, PoolsSingleResponse,
 };
 use bf_common::{pagination::Pagination, types::ApiResult};
 
@@ -42,5 +43,15 @@ impl DataNodePools<'_> {
         let path = format!("pools/{pool_id}/metadata");
 
         self.inner.client.get(&path, None).await
+    }
+
+    pub async fn history(
+        &self,
+        pool_id: &str,
+        pagination: &Pagination,
+    ) -> ApiResult<PoolsHistoryResponse> {
+        let path = format!("pools/{pool_id}/history");
+
+        self.inner.client.get(&path, Some(pagination)).await
     }
 }

--- a/crates/data_node/src/api/scripts.rs
+++ b/crates/data_node/src/api/scripts.rs
@@ -1,0 +1,48 @@
+use crate::client::DataNode;
+use bf_api_provider::types::{
+    ScriptsCborResponse, ScriptsDatumCborResponse, ScriptsDatumResponse, ScriptsJsonResponse,
+    ScriptsSingleResponse,
+};
+use bf_common::types::ApiResult;
+
+pub struct DataNodeScripts<'a> {
+    pub(crate) inner: &'a DataNode,
+}
+
+impl DataNode {
+    pub fn scripts(&self) -> DataNodeScripts<'_> {
+        DataNodeScripts { inner: self }
+    }
+}
+
+impl DataNodeScripts<'_> {
+    pub async fn by(&self, script_hash: &str) -> ApiResult<ScriptsSingleResponse> {
+        let path = format!("scripts/{script_hash}");
+
+        self.inner.client.get(&path, None).await
+    }
+
+    pub async fn json(&self, script_hash: &str) -> ApiResult<ScriptsJsonResponse> {
+        let path = format!("scripts/{script_hash}/json");
+
+        self.inner.client.get(&path, None).await
+    }
+
+    pub async fn cbor(&self, script_hash: &str) -> ApiResult<ScriptsCborResponse> {
+        let path = format!("scripts/{script_hash}/cbor");
+
+        self.inner.client.get(&path, None).await
+    }
+
+    pub async fn datum(&self, datum_hash: &str) -> ApiResult<ScriptsDatumResponse> {
+        let path = format!("scripts/datum/{datum_hash}");
+
+        self.inner.client.get(&path, None).await
+    }
+
+    pub async fn datum_cbor(&self, datum_hash: &str) -> ApiResult<ScriptsDatumCborResponse> {
+        let path = format!("scripts/datum/{datum_hash}/cbor");
+
+        self.inner.client.get(&path, None).await
+    }
+}

--- a/crates/integration_tests/tests/data/ignored_tests.json
+++ b/crates/integration_tests/tests/data/ignored_tests.json
@@ -87,6 +87,146 @@
     {
       "_comment": "txs/f1aee024a482d5d21ed552d15eefbb664e98095cdabde75a9ff9c78c0812e6fb/pool_updates",
       "id": "txs-tx-generic-shelley-with-multiple-delegation-stake-certs-and-pool-updates_474556906a6a"
+    },
+    {
+      "_comment": "addresses/addr_vkh15ew2tzjwn364l2pszu7j5h9w63v2crrnl97m074w9elrk6zy2tc/txs?order=asc&page=42000 -- Dolos HTTP 400 (scan limit: page*count=4200000 > max_scan_items=3000); real Blockfrost returns the full array",
+      "id": "addresses-address-txs-generic-payment-cred-1_ada2582fd6c1"
+    },
+    {
+      "_comment": "addresses/addr_vkh15ew2tzjwn364l2pszu7j5h9w63v2crrnl97m074w9elrk6zy2tc/txs?order=asc&page=69000&count=1 -- Dolos HTTP 400 (scan limit: page*count=69000 > max_scan_items=3000); real Blockfrost returns the full array",
+      "id": "addresses-address-txs-generic-payment-cred-2_32870c25a11c"
+    },
+    {
+      "_comment": "addresses/addr_vkh15ew2tzjwn364l2pszu7j5h9w63v2crrnl97m074w9elrk6zy2tc/txs?page=16884 (and ?page=16884&count=100, ?order=asc&page=16884) -- Dolos HTTP 400 (scan limit: page*count=1688400 > max_scan_items=3000); real Blockfrost returns the full array",
+      "id": "addresses-address-txs-generic-payment-cred-3-page-with-self-tx-in-the-same-block-and-index-same-pc-different-addresses_0d3b9c63b44e"
+    },
+    {
+      "_comment": "assets/a0028f350aaabe0545fdcb56b039bfb08e4bb4d8c4d7c3c7d481c235484f534b59/transactions?page=42420 (HOSKY) -- Dolos HTTP 400 (scan limit: page*count=4242000 > max_scan_items=3000); real Blockfrost returns the full array",
+      "id": "assets-a0028f350aaabe0545fdcb56b039bfb08e4bb4d8c4d7c3c7d481c235484f534b59-transactions-hosky-precached-response_0faa4380de39"
+    },
+    {
+      "_comment": "assets/d894897411707efa755a76deb66d26dfd50593f2e70863e1661e98a07370616365636f696e73/transactions?count=3&page=10000 -- Dolos HTTP 400 (scan limit: page*count=30000 > max_scan_items=3000); real Blockfrost returns the full array",
+      "id": "assets-asset-transactions-queryparams-spacecoin-many-transactions_8722d3782835"
+    },
+    {
+      "_comment": "assets/d894897411707efa755a76deb66d26dfd50593f2e70863e1661e98a07370616365636f696e73/transactions?page=324 -- Dolos HTTP 400 (scan limit: page*count=32400 > max_scan_items=3000); real Blockfrost returns the full array",
+      "id": "assets-d894897411707efa755a76deb66d26dfd50593f2e70863e1661e98a07370616365636f696e73-transactions-precached-response_e7ca9da59175"
+    },
+    {
+      "_comment": "assets/4247d5091db82330100904963ab8d0850976c80d3f1b927e052e07bd546f6b68756e/transactions?page=324 -- Dolos HTTP 400 (scan limit: page*count=32400 > max_scan_items=3000); real Blockfrost returns the full array",
+      "id": "assets-4247d5091db82330100904963ab8d0850976c80d3f1b927e052e07bd546f6b68756e-transactions-precached-response_225b895a298d"
+    },
+    {
+      "_comment": "assets/8654e8b350e298c80d2451beb5ed80fc9eee9f38ce6b039fb8706bc34c4f4253544552/transactions?page=324 -- Dolos HTTP 400 (scan limit: page*count=32400 > max_scan_items=3000); real Blockfrost returns the full array",
+      "id": "assets-8654e8b350e298c80d2451beb5ed80fc9eee9f38ce6b039fb8706bc34c4f4253544552-transactions-precached-response_bfbd77884ad8"
+    },
+    {
+      "_comment": "assets/9a9693a9a37912a5097918f97918d15240c92ab729a0b7c4aa144d7753554e444145/transactions?page=324 -- Dolos HTTP 400 (scan limit: page*count=32400 > max_scan_items=3000); real Blockfrost returns the full array",
+      "id": "assets-9a9693a9a37912a5097918f97918d15240c92ab729a0b7c4aa144d7753554e444145-transactions-precached-response_cf792faf6054"
+    },
+    {
+      "_comment": "assets/5ad8deb64bfec21ad2d96e1270b5873d0c4d0f231b928b4c39eb243561646f736961/transactions?page=324 -- Dolos HTTP 400 (scan limit: page*count=32400 > max_scan_items=3000); real Blockfrost returns the full array",
+      "id": "assets-5ad8deb64bfec21ad2d96e1270b5873d0c4d0f231b928b4c39eb243561646f736961-transactions-precached-response_f02d9beb28f7"
+    },
+    {
+      "_comment": "assets/29d222ce763455e3d7a09a665ce554f00ac89d2e99a1a83d267170c64d494e/transactions?page=324 -- Dolos HTTP 400 (scan limit: page*count=32400 > max_scan_items=3000); real Blockfrost returns the full array",
+      "id": "assets-29d222ce763455e3d7a09a665ce554f00ac89d2e99a1a83d267170c64d494e-transactions-precached-response_32bdd7dd07ae"
+    },
+    {
+      "_comment": "assets/afc910d7a306d20c12903979d4935ae4307241d03245743548e767834153484942/transactions?page=324 -- Dolos HTTP 400 (scan limit: page*count=32400 > max_scan_items=3000); real Blockfrost returns the full array",
+      "id": "assets-afc910d7a306d20c12903979d4935ae4307241d03245743548e767834153484942-transactions-precached-response_9f2e460c147c"
+    },
+    {
+      "_comment": "assets/b6a7467ea1deb012808ef4e87b5ff371e85f7142d7b356a40d9b42a0436f726e75636f70696173205b76696120436861696e506f72742e696f5d/transactions?page=324 (Cornucopias) -- Dolos HTTP 400 (scan limit: page*count=32400 > max_scan_items=3000); real Blockfrost returns the full array",
+      "id": "assets-b6a7467ea1deb012808ef4e87b5ff371e85f7142d7b356a40d9b42a0436f726e75636f70696173205b76696120436861696e506f72742e696f5d-transactions-precached-response_f8bb635683ce"
+    },
+    {
+      "_comment": "assets/b788fbee71a32d2efc5ee7d151f3917d99160f78fb1e41a1bbf80d8f4c454146544f4b454e/transactions?page=324 -- Dolos HTTP 400 (scan limit: page*count=32400 > max_scan_items=3000); real Blockfrost returns the full array",
+      "id": "assets-b788fbee71a32d2efc5ee7d151f3917d99160f78fb1e41a1bbf80d8f4c454146544f4b454e-transactions-precached-response_bbee8993b3a1"
+    },
+    {
+      "_comment": "assets/6954264b15bc92d6d592febeac84f14645e1ed46ca5ebb9acdb5c15f5354524950/transactions?page=324 -- Dolos HTTP 400 (scan limit: page*count=32400 > max_scan_items=3000); real Blockfrost returns the full array",
+      "id": "assets-6954264b15bc92d6d592febeac84f14645e1ed46ca5ebb9acdb5c15f5354524950-transactions-precached-response_475951e2b18c"
+    },
+    {
+      "_comment": "assets/d030b626219d81673bd32932d2245e0c71ae5193281f971022b23a78436172646f67656f/transactions?page=324 -- Dolos HTTP 400 (scan limit: page*count=32400 > max_scan_items=3000); real Blockfrost returns the full array",
+      "id": "assets-d030b626219d81673bd32932d2245e0c71ae5193281f971022b23a78436172646f67656f-transactions-precached-response_ab352857d975"
+    },
+    {
+      "_comment": "assets/a4da8764a57e66a0085b5bfcde96c89b798d92ee83a75f59237e375b46495245/transactions?page=324 -- Dolos HTTP 400 (scan limit: page*count=32400 > max_scan_items=3000); real Blockfrost returns the full array",
+      "id": "assets-a4da8764a57e66a0085b5bfcde96c89b798d92ee83a75f59237e375b46495245-transactions-precached-response_a0ea7b114e06"
+    },
+    {
+      "_comment": "assets/2d7444cf9e317a12e3eb72bf424fd2a0c8fbafedf10e20bfdb4ad8ab434845444441/transactions?page=324 -- Dolos HTTP 400 (scan limit: page*count=32400 > max_scan_items=3000); real Blockfrost returns the full array",
+      "id": "assets-2d7444cf9e317a12e3eb72bf424fd2a0c8fbafedf10e20bfdb4ad8ab434845444441-transactions-precached-response_6465ed1c1942"
+    },
+    {
+      "_comment": "assets/2afb448ef716bfbed1dcb676102194c3009bee5399e93b90def9db6a4249534f4e/transactions?page=324 -- Dolos HTTP 400 (scan limit: page*count=32400 > max_scan_items=3000); real Blockfrost returns the full array",
+      "id": "assets-2afb448ef716bfbed1dcb676102194c3009bee5399e93b90def9db6a4249534f4e-transactions-precached-response_dbf9e8243238"
+    },
+    {
+      "_comment": "assets/544571c086d0e5c5022aca9717dd0f438e21190abb48f37b3ae129f047524f57/transactions?page=324 -- Dolos HTTP 400 (scan limit: page*count=32400 > max_scan_items=3000); real Blockfrost returns the full array",
+      "id": "assets-544571c086d0e5c5022aca9717dd0f438e21190abb48f37b3ae129f047524f57-transactions-precached-response_a19a3a940280"
+    },
+    {
+      "_comment": "assets/1a71dc14baa0b4fcfb34464adc6656d0e562571e2ac1bc990c9ce5f6574f4c46/transactions?page=324 -- Dolos HTTP 400 (scan limit: page*count=32400 > max_scan_items=3000); real Blockfrost returns the full array",
+      "id": "assets-1a71dc14baa0b4fcfb34464adc6656d0e562571e2ac1bc990c9ce5f6574f4c46-transactions-precached-response_a17efca1749d"
+    },
+    {
+      "_comment": "assets/1d7f33bd23d85e1a25d87d86fac4f199c3197a2f7afeb662a0f34e1e776f726c646d6f62696c65746f6b656e/transactions?page=324 -- Dolos HTTP 400 (scan limit: page*count=32400 > max_scan_items=3000); real Blockfrost returns the full array",
+      "id": "assets-1d7f33bd23d85e1a25d87d86fac4f199c3197a2f7afeb662a0f34e1e776f726c646d6f62696c65746f6b656e-transactions-precached-response_60f1cc9aed39"
+    },
+    {
+      "_comment": "assets/884892bcdc360bcef87d6b3f806e7f9cd5ac30d999d49970e7a903ae5041564941/transactions?page=324 -- Dolos HTTP 400 (scan limit: page*count=32400 > max_scan_items=3000); real Blockfrost returns the full array",
+      "id": "assets-884892bcdc360bcef87d6b3f806e7f9cd5ac30d999d49970e7a903ae5041564941-transactions-precached-response_448355cab1f4"
+    },
+    {
+      "_comment": "assets/b7c783f6304eddbdf8f0dece4715d63cb9f453be89d97c8fba155d5752455349/transactions?page=324 -- Dolos HTTP 400 (scan limit: page*count=32400 > max_scan_items=3000); real Blockfrost returns the full array",
+      "id": "assets-b7c783f6304eddbdf8f0dece4715d63cb9f453be89d97c8fba155d5752455349-transactions-precached-response_4c3fbb68a240"
+    },
+    {
+      "_comment": "assets/d1333653aa3ac24adfa9c6d09c1a2cc8e2b7b86ad334c17f2acb864742696f546f6b656e/transactions?page=324 -- Dolos HTTP 400 (scan limit: page*count=32400 > max_scan_items=3000); real Blockfrost returns the full array",
+      "id": "assets-d1333653aa3ac24adfa9c6d09c1a2cc8e2b7b86ad334c17f2acb864742696f546f6b656e-transactions-precached-response_21480def6ab7"
+    },
+    {
+      "_comment": "assets/f28f457472e539dc75e1598a2beddf49ce5a717998c708f05f5de61044454653/transactions?page=324 -- Dolos HTTP 400 (scan limit: page*count=32400 > max_scan_items=3000); real Blockfrost returns the full array",
+      "id": "assets-f28f457472e539dc75e1598a2beddf49ce5a717998c708f05f5de61044454653-transactions-precached-response_ec57702306e4"
+    },
+    {
+      "_comment": "assets/ff97c85de383ebf0b047667ef23c697967719def58d380caf7f04b64534f554c/transactions?page=324 -- Dolos HTTP 400 (scan limit: page*count=32400 > max_scan_items=3000); real Blockfrost returns the full array",
+      "id": "assets-ff97c85de383ebf0b047667ef23c697967719def58d380caf7f04b64534f554c-transactions-precached-response_2cf10ffcc87d"
+    },
+    {
+      "_comment": "assets/6ac8ef33b510ec004fe11585f7c5a9f0c07f0c23428ab4f29c1d7d104d454c44/transactions?page=324 -- Dolos HTTP 400 (scan limit: page*count=32400 > max_scan_items=3000); real Blockfrost returns the full array",
+      "id": "assets-6ac8ef33b510ec004fe11585f7c5a9f0c07f0c23428ab4f29c1d7d104d454c44-transactions-precached-response_8eef660e9383"
+    },
+    {
+      "_comment": "assets/641f0571d02b45b868ac1c479fc8118c5be6744ec3d2c5e13bd888b65a4f4d424945/transactions?page=324 -- Dolos HTTP 400 (scan limit: page*count=32400 > max_scan_items=3000); real Blockfrost returns the full array",
+      "id": "assets-641f0571d02b45b868ac1c479fc8118c5be6744ec3d2c5e13bd888b65a4f4d424945-transactions-precached-response_976b23bf49da"
+    },
+    {
+      "_comment": "assets/4fd0d998dc0700ca6ef89fafff05fbf523a3a25c1fc8314bf7e4d1c247726f777468/transactions?page=324 -- Dolos HTTP 400 (scan limit: page*count=32400 > max_scan_items=3000); real Blockfrost returns the full array",
+      "id": "assets-4fd0d998dc0700ca6ef89fafff05fbf523a3a25c1fc8314bf7e4d1c247726f777468-transactions-precached-response_8a76d2a65dff"
+    },
+    {
+      "_comment": "assets/ddd01d9531fcc25e3ca4b6429318c2cc374dbdbcf5e99c1c1e5da1ff444f4e545350414d/addresses -- Dolos returns an empty array [] for a valid asset that was never minted on-chain, while the real Blockfrost API returns HTTP 404 Not Found",
+      "id": "assets-addresses-valid-not-on-chain-asset_3ad55423382f"
+    },
+    {
+      "_comment": "epochs/123/blocks?count=2 -- Dolos omits the Byron epoch boundary block (EBB) from the block list, yielding different hashes than the real Blockfrost API",
+      "id": "epochs-number-blocks-queryparams-first-blocks-generic-byron-epoch_38950d09cab0"
+    },
+    {
+      "_comment": "epochs/123/blocks?count=2&order=desc -- Dolos omits the Byron epoch boundary block (EBB) from the block list, yielding different hashes than the real Blockfrost API",
+      "id": "epochs-number-blocks-queryparams-last-blocks-generic-byron-epoch_b7676ba66e29"
+    },
+    {
+      "_comment": "pools/pool1pu5jlj4q9w9jlxeu370a3c9myx47md5j5m2str0naunn2q3lkdy/history?count=10 (= pools/0f292fcaa02b8b2f9b3c8f9fd8e0bb21abedb692a6d5058df3ef2735/history?count=10) -- Dolos pool history differs from the real Blockfrost API (missing the pool's initial registration epoch; f64 active_size precision and reward/fee rounding differences)",
+      "id": "pools-pool-id-history-best-pool-history_c4f95a045f23"
+    },
+    {
+      "_comment": "pools/pool1r8lmsrdure385hz647kl2qjhyyxkdle4au5krjcsqed4x8227k3/history?page=2 -- Dolos pool history differs from the real Blockfrost API (f64 active_size precision / missing epochs)",
+      "id": "pools-pool-id-history-problematic-pool-history-dbsync-issue-missing-some-epochs_912a978ee4cf"
     }
   ],
   "preprod": [
@@ -109,6 +249,38 @@
     {
       "_comment": "accounts/stake_test1uzkdwx64sjkt6xxtzye00y3k2m9wn5zultsguadaf4ggmssadyunp/addresses",
       "id": "accounts-stake-address-generic-stake-address-with-zero-addresses_4261465085d4"
+    },
+    {
+      "_comment": "addresses/addr_test1wrrgep77m0v8uv5unauluwgyr7pmdr2827wgye3sx5aw7yg7z2dsu/txs?page=1011&count=6 (= addr_vkh1c6xg0hkmmplr98yl08lrjpqlswmg636hnjpxvvp48th3zsq296f) -- Dolos HTTP 400 (scan limit: page*count=6066 > max_scan_items=3000); real Blockfrost returns the full array",
+      "id": "addresses-address-txs-generic-dormant-shelley-address_c9a9236e94d8"
+    },
+    {
+      "_comment": "addresses/addr_test1wrrgep77m0v8uv5unauluwgyr7pmdr2827wgye3sx5aw7yg7z2dsu/txs?page=1011&count=99&order=desc (= addr_vkh1c6xg0hkmmplr98yl08lrjpqlswmg636hnjpxvvp48th3zsq296f) -- Dolos HTTP 400 (scan limit: page*count=100089 > max_scan_items=3000); real Blockfrost returns the full array",
+      "id": "addresses-address-txs-generic-dormant-shelley-address-desc_9af6dc662686"
+    },
+    {
+      "_comment": "addresses/addr_vkh1pjggm5nyjkll8amnrsh4hvjz6zsdvr9knmnlsgtgczls7x9qy3y/txs?order=asc&page=420 -- Dolos HTTP 400 (scan limit: page*count=42000 > max_scan_items=3000); real Blockfrost returns the full array",
+      "id": "addresses-address-txs-generic-payment-cred-1_957944637cb5"
+    },
+    {
+      "_comment": "addresses/addr_vkh1pjggm5nyjkll8amnrsh4hvjz6zsdvr9knmnlsgtgczls7x9qy3y/txs?order=asc&page=42000&count=1 -- Dolos HTTP 400 (scan limit: page*count=42000 > max_scan_items=3000); real Blockfrost returns the full array",
+      "id": "addresses-address-txs-generic-payment-cred-2_209c6157eb4b"
+    },
+    {
+      "_comment": "assets/e68f1cea19752d1292b4be71b7f5d2b3219a15859c028f7454f66cdf74544555524f/transactions?page=50 (tEURO) -- Dolos HTTP 400 (scan limit: page*count=5000 > max_scan_items=3000); real Blockfrost returns the full array",
+      "id": "assets-e68f1cea19752d1292b4be71b7f5d2b3219a15859c028f7454f66cdf74544555524f-transactions-t-teuro-precached-response_18a9a530c7f7"
+    },
+    {
+      "_comment": "epochs/latest/parameters -- Dolos v1.2.0 on Preprod returns an older protocol version (v10) with a reduced cost-model set, while the real Blockfrost API returns the current params (v11). Known Dolos limitation on Preprod.",
+      "id": "epochs-latest-parameters-latest-epoch_a73a0c95ff80"
+    },
+    {
+      "_comment": "pools/pool13m26ky08vz205232k20u8ft5nrg8u68klhn0xfsk9m4gsqsc44v/history?count=10 (= pools/8ed5ab11e76094fa2a2ab29fc3a57498d07e68f6fde6f326162eea88/history?count=10) -- Dolos pool history differs from the real Blockfrost API (delegators_count differences)",
+      "id": "pools-pool-id-history-best-pool-history_df31300e4408"
+    },
+    {
+      "_comment": "pools/pool1rccstu3l9ty3k0a5cd06fl3szsss9r34dcg5j38fqgq9kvng0tg/history?page=5&count=1 (= pools/1e3105f23f2ac91b3fb4c35fa4fe301421028e356e114944e902005b/history?page=5&count=1&order=asc) -- Dolos pool history differs from the real Blockfrost API (delegators_count / margin-cost update differences)",
+      "id": "pools-pool-id-history-pool-history-with-more-margin-cost-updates_d0b3a9122929"
     }
   ],
   "preview": [

--- a/crates/integration_tests/tests/data/ignored_tests.json
+++ b/crates/integration_tests/tests/data/ignored_tests.json
@@ -119,6 +119,14 @@
     {
       "_comment": "blocks/0",
       "id": "blocks-hash-or-number-first-blocks-0-4_8a1bd8d1903e"
+    },
+    {
+      "_comment": "addresses/addr_vkh12ux0cq59haf8ydty5577ztxzh9qcvhjn7xxaj4xr55esx49uztj/txs?order=asc&page=128, addresses/addr_vkh12ux0cq59haf8ydty5577ztxzh9qcvhjn7xxaj4xr55esx49uztj/txs?page=128 -- Dolos returns HTTP 400 (pagination scan limit: page*count=12800 > max_scan_items=3000) while the real Blockfrost API returns the full array",
+      "id": "addresses-address-txs-generic-payment-cred-1_a8e5c9c0ea73"
+    },
+    {
+      "_comment": "addresses/addr_vkh12ux0cq59haf8ydty5577ztxzh9qcvhjn7xxaj4xr55esx49uztj/txs?order=asc&page=12800&count=1 -- Dolos returns HTTP 400 (pagination scan limit: page*count=12800 > max_scan_items=3000) while the real Blockfrost API returns the full array",
+      "id": "addresses-address-txs-generic-payment-cred-2_ba6a4f5de054"
     }
   ]
 }

--- a/crates/integration_tests/tests/data/supported_endpoints.json
+++ b/crates/integration_tests/tests/data/supported_endpoints.json
@@ -41,6 +41,16 @@
   "/epochs/latest/parameters",
   "/genesis",
   "/addresses/{address}/transactions",
+  "/addresses/{address}/txs",
   "/addresses/{address}/utxos",
-  "/addresses/{address}"
+  "/addresses/{address}",
+  "/assets/{asset}/addresses",
+  "/assets/{asset}/transactions",
+  "/epochs/{number}/blocks",
+  "/pools/{pool_id}/history",
+  "/scripts/{script_hash}",
+  "/scripts/{script_hash}/json",
+  "/scripts/{script_hash}/cbor",
+  "/scripts/datum/{datum_hash}",
+  "/scripts/datum/{datum_hash}/cbor"
 ]

--- a/crates/platform/src/api/addresses/address.rs
+++ b/crates/platform/src/api/addresses/address.rs
@@ -2,4 +2,5 @@ pub mod extended;
 pub mod root;
 pub mod total;
 pub mod transactions;
+pub mod txs;
 pub mod utxos;

--- a/crates/platform/src/api/addresses/address/txs.rs
+++ b/crates/platform/src/api/addresses/address/txs.rs
@@ -1,0 +1,25 @@
+use crate::addresses::{AddressInfo, AddressesPath};
+use crate::server::state::AppState;
+use axum::extract::{Path, Query, State};
+use bf_common::{
+    pagination::{Pagination, PaginationQuery},
+    types::ApiResult,
+};
+
+/// `/addresses/{address}/txs` returns a bare list of transaction hashes (as
+/// opposed to `/addresses/{address}/transactions`, which returns objects).
+pub async fn route(
+    State(state): State<AppState>,
+    Path(address_path): Path<AddressesPath>,
+    Query(pagination_query): Query<PaginationQuery>,
+) -> ApiResult<Vec<String>> {
+    let AddressesPath { address, asset: _ } = address_path;
+    let pagination = Pagination::from_query(pagination_query)?;
+    let address_info = AddressInfo::from_address(&address, state.config.network.clone())?;
+    let data_node = state.data_node()?;
+
+    data_node
+        .addresses()
+        .txs(&address_info.address, &pagination)
+        .await
+}

--- a/crates/platform/src/api/assets/asset/addresses.rs
+++ b/crates/platform/src/api/assets/asset/addresses.rs
@@ -1,12 +1,20 @@
-use crate::{BlockfrostError, api::ApiResult};
-use axum::extract::Query;
+use crate::assets::{AssetData, AssetsPath};
+use crate::{api::ApiResult, server::state::AppState};
+use axum::extract::{Path, Query, State};
 use bf_api_provider::types::AssetsAddressesResponse;
 use bf_common::pagination::{Pagination, PaginationQuery};
 
 pub async fn route(
+    State(state): State<AppState>,
+    Path(path): Path<AssetsPath>,
     Query(pagination_query): Query<PaginationQuery>,
 ) -> ApiResult<AssetsAddressesResponse> {
-    let _ = Pagination::from_query(pagination_query)?;
+    let asset_data = AssetData::from_query(path.asset)?;
+    let pagination = Pagination::from_query(pagination_query)?;
+    let data_node = state.data_node()?;
 
-    Err(BlockfrostError::not_found())
+    data_node
+        .assets()
+        .addresses(&asset_data.asset, &pagination)
+        .await
 }

--- a/crates/platform/src/api/assets/asset/transactions.rs
+++ b/crates/platform/src/api/assets/asset/transactions.rs
@@ -1,15 +1,20 @@
 use crate::assets::{AssetData, AssetsPath};
-use crate::{BlockfrostError, api::ApiResult};
-use axum::extract::{Path, Query};
+use crate::{api::ApiResult, server::state::AppState};
+use axum::extract::{Path, Query, State};
 use bf_api_provider::types::AssetsTransactionsResponse;
 use bf_common::pagination::{Pagination, PaginationQuery};
 
 pub async fn route(
+    State(state): State<AppState>,
     Path(path): Path<AssetsPath>,
     Query(pagination_query): Query<PaginationQuery>,
 ) -> ApiResult<AssetsTransactionsResponse> {
-    let _ = AssetData::from_query(path.asset)?;
-    let _ = Pagination::from_query(pagination_query)?;
+    let asset_data = AssetData::from_query(path.asset)?;
+    let pagination = Pagination::from_query(pagination_query)?;
+    let data_node = state.data_node()?;
 
-    Err(BlockfrostError::not_found())
+    data_node
+        .assets()
+        .transactions(&asset_data.asset, &pagination)
+        .await
 }

--- a/crates/platform/src/api/epochs/number/blocks/root.rs
+++ b/crates/platform/src/api/epochs/number/blocks/root.rs
@@ -1,6 +1,20 @@
-use crate::{BlockfrostError, api::ApiResult};
-use bf_api_provider::types::EpochsStakeResponse;
+use crate::api::ApiResult;
+use crate::epochs::{EpochData, EpochsPath};
+use crate::server::state::AppState;
+use axum::extract::{Path, Query, State};
+use bf_common::pagination::{Pagination, PaginationQuery};
 
-pub async fn route() -> ApiResult<EpochsStakeResponse> {
-    Err(BlockfrostError::not_found())
+pub async fn route(
+    State(state): State<AppState>,
+    Path(epochs_path): Path<EpochsPath>,
+    Query(pagination_query): Query<PaginationQuery>,
+) -> ApiResult<Vec<String>> {
+    let epoch_data = EpochData::from_path(epochs_path.epoch_number, &state.config.network)?;
+    let pagination = Pagination::from_query(pagination_query)?;
+    let data_node = state.data_node()?;
+
+    data_node
+        .epochs()
+        .blocks(&epoch_data.epoch_number, &pagination)
+        .await
 }

--- a/crates/platform/src/api/pools/pool_id/history.rs
+++ b/crates/platform/src/api/pools/pool_id/history.rs
@@ -1,6 +1,20 @@
-use crate::{BlockfrostError, api::ApiResult};
+use crate::pools::{PoolData, PoolsPath};
+use crate::{api::ApiResult, server::state::AppState};
+use axum::extract::{Path, Query, State};
 use bf_api_provider::types::PoolsHistoryResponse;
+use bf_common::pagination::{Pagination, PaginationQuery};
 
-pub async fn route() -> ApiResult<PoolsHistoryResponse> {
-    Err(BlockfrostError::not_found())
+pub async fn route(
+    State(state): State<AppState>,
+    Query(pagination_query): Query<PaginationQuery>,
+    Path(pools_path): Path<PoolsPath>,
+) -> ApiResult<PoolsHistoryResponse> {
+    let pool_data = PoolData::from_path(&pools_path.pool_id)?;
+    let pagination = Pagination::from_query(pagination_query)?;
+    let data_node = state.data_node()?;
+
+    data_node
+        .pools()
+        .history(&pool_data.pool_id, &pagination)
+        .await
 }

--- a/crates/platform/src/api/scripts/datum/datum_hash/cbor.rs
+++ b/crates/platform/src/api/scripts/datum/datum_hash/cbor.rs
@@ -1,6 +1,12 @@
-use crate::{BlockfrostError, api::ApiResult};
+use crate::{api::ApiResult, server::state::AppState};
+use axum::extract::{Path, State};
 use bf_api_provider::types::ScriptsDatumCborResponse;
 
-pub async fn route() -> ApiResult<ScriptsDatumCborResponse> {
-    Err(BlockfrostError::not_found())
+pub async fn route(
+    State(state): State<AppState>,
+    Path(datum_hash): Path<String>,
+) -> ApiResult<ScriptsDatumCborResponse> {
+    let data_node = state.data_node()?;
+
+    data_node.scripts().datum_cbor(&datum_hash).await
 }

--- a/crates/platform/src/api/scripts/datum/datum_hash/root.rs
+++ b/crates/platform/src/api/scripts/datum/datum_hash/root.rs
@@ -1,5 +1,12 @@
-use crate::{BlockfrostError, api::ApiResult};
+use crate::{api::ApiResult, server::state::AppState};
+use axum::extract::{Path, State};
+use bf_api_provider::types::ScriptsDatumResponse;
 
-pub async fn route() -> ApiResult<Vec<String>> {
-    Err(BlockfrostError::not_found())
+pub async fn route(
+    State(state): State<AppState>,
+    Path(datum_hash): Path<String>,
+) -> ApiResult<ScriptsDatumResponse> {
+    let data_node = state.data_node()?;
+
+    data_node.scripts().datum(&datum_hash).await
 }

--- a/crates/platform/src/api/scripts/script_hash/cbor.rs
+++ b/crates/platform/src/api/scripts/script_hash/cbor.rs
@@ -1,6 +1,12 @@
-use crate::{BlockfrostError, api::ApiResult};
+use crate::{api::ApiResult, server::state::AppState};
+use axum::extract::{Path, State};
 use bf_api_provider::types::ScriptsCborResponse;
 
-pub async fn route() -> ApiResult<ScriptsCborResponse> {
-    Err(BlockfrostError::not_found())
+pub async fn route(
+    State(state): State<AppState>,
+    Path(script_hash): Path<String>,
+) -> ApiResult<ScriptsCborResponse> {
+    let data_node = state.data_node()?;
+
+    data_node.scripts().cbor(&script_hash).await
 }

--- a/crates/platform/src/api/scripts/script_hash/json.rs
+++ b/crates/platform/src/api/scripts/script_hash/json.rs
@@ -1,6 +1,12 @@
-use crate::{BlockfrostError, api::ApiResult};
+use crate::{api::ApiResult, server::state::AppState};
+use axum::extract::{Path, State};
 use bf_api_provider::types::ScriptsJsonResponse;
 
-pub async fn route() -> ApiResult<ScriptsJsonResponse> {
-    Err(BlockfrostError::not_found())
+pub async fn route(
+    State(state): State<AppState>,
+    Path(script_hash): Path<String>,
+) -> ApiResult<ScriptsJsonResponse> {
+    let data_node = state.data_node()?;
+
+    data_node.scripts().json(&script_hash).await
 }

--- a/crates/platform/src/api/scripts/script_hash/root.rs
+++ b/crates/platform/src/api/scripts/script_hash/root.rs
@@ -1,6 +1,12 @@
-use crate::{BlockfrostError, api::ApiResult};
+use crate::{api::ApiResult, server::state::AppState};
+use axum::extract::{Path, State};
 use bf_api_provider::types::ScriptsSingleResponse;
 
-pub async fn route() -> ApiResult<ScriptsSingleResponse> {
-    Err(BlockfrostError::not_found())
+pub async fn route(
+    State(state): State<AppState>,
+    Path(script_hash): Path<String>,
+) -> ApiResult<ScriptsSingleResponse> {
+    let data_node = state.data_node()?;
+
+    data_node.scripts().by(&script_hash).await
 }

--- a/crates/platform/src/server/routes/hidden.rs
+++ b/crates/platform/src/server/routes/hidden.rs
@@ -33,6 +33,7 @@ pub fn get_hidden_api_routes(enable_metrics: bool) -> Router<AppState> {
         .route("/addresses/{address}/utxos", get(addresses::address::utxos::root::route))
         .route("/addresses/{address}/utxos/{asset}", get(addresses::address::utxos::asset::route))
         .route("/addresses/{address}/transactions", get(addresses::address::transactions::route))
+        .route("/addresses/{address}/txs", get(addresses::address::txs::route))
 
         // assets
         .route("/assets", get(assets::root::route))


### PR DESCRIPTION
## Context

A few more endpoints, stacked on top of:
- #591

See <https://docs.txpipe.io/dolos/apis/minibf>.

### Ignored tests

Unfortunately a few tests had to be ignored, mostly because they reach too deeply into pagination, and Dolos returns a 400…

More controversial ignores (reasons in comments):

- https://github.com/blockfrost/blockfrost-platform/blob/6f4b781119c61d2befb0557cd11a51f2b6d49d44/crates/integration_tests/tests/data/ignored_tests.json#L211-L214

- https://github.com/blockfrost/blockfrost-platform/blob/6f4b781119c61d2befb0557cd11a51f2b6d49d44/crates/integration_tests/tests/data/ignored_tests.json#L215-L222

- https://github.com/blockfrost/blockfrost-platform/blob/6f4b781119c61d2befb0557cd11a51f2b6d49d44/crates/integration_tests/tests/data/ignored_tests.json#L223-L230

- https://github.com/blockfrost/blockfrost-platform/blob/6f4b781119c61d2befb0557cd11a51f2b6d49d44/crates/integration_tests/tests/data/ignored_tests.json#L277-L284

I have also ignored the Preprod v10 / v11 failure – the "Ignored" check will fail, once we have the next Dolos release.