### PR TITLE
chore: update Dolos to 1.3.2

### DIFF
--- a/crates/integration_tests/tests/data/ignored_tests.json
+++ b/crates/integration_tests/tests/data/ignored_tests.json
@@ -271,10 +271,6 @@
       "id": "assets-e68f1cea19752d1292b4be71b7f5d2b3219a15859c028f7454f66cdf74544555524f-transactions-t-teuro-precached-response_18a9a530c7f7"
     },
     {
-      "_comment": "epochs/latest/parameters -- Dolos v1.2.0 on Preprod returns an older protocol version (v10) with a reduced cost-model set, while the real Blockfrost API returns the current params (v11). Known Dolos limitation on Preprod.",
-      "id": "epochs-latest-parameters-latest-epoch_a73a0c95ff80"
-    },
-    {
       "_comment": "pools/pool13m26ky08vz205232k20u8ft5nrg8u68klhn0xfsk9m4gsqsc44v/history?count=10 (= pools/8ed5ab11e76094fa2a2ab29fc3a57498d07e68f6fde6f326162eea88/history?count=10) -- Dolos pool history differs from the real Blockfrost API (delegators_count differences)",
       "id": "pools-pool-id-history-best-pool-history_df31300e4408"
     },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       init-node:
         condition: service_completed_successfully
   dolos:
-    image: ghcr.io/txpipe/dolos:v1.0.3
+    image: ghcr.io/txpipe/dolos:v1.3.1
     entrypoint: /entrypoint.sh
     environment:
       NETWORK: $NETWORK

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       init-node:
         condition: service_completed_successfully
   dolos:
-    image: ghcr.io/txpipe/dolos:v1.3.1
+    image: ghcr.io/txpipe/dolos:v1.3.2
     entrypoint: /entrypoint.sh
     environment:
       NETWORK: $NETWORK

--- a/flake.lock
+++ b/flake.lock
@@ -119,16 +119,16 @@
     "dolos": {
       "flake": false,
       "locked": {
-        "lastModified": 1781915104,
-        "narHash": "sha256-IOD3rpyt0HNxapVxPn+xGwF3hMlQCLpBDbX+FzZtjmw=",
+        "lastModified": 1782215327,
+        "narHash": "sha256-tKhGe0eIiBR0H7fZS3/yOnEBxoAGJFVKxqIiNac9V3U=",
         "owner": "txpipe",
         "repo": "dolos",
-        "rev": "534158e2b7c7275fa1815816f4055842bca5abb6",
+        "rev": "ea7960a1c2e56c523fec7c4bab75f390ee443514",
         "type": "github"
       },
       "original": {
         "owner": "txpipe",
-        "ref": "v1.3.1",
+        "ref": "v1.3.2",
         "repo": "dolos",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -119,16 +119,16 @@
     "dolos": {
       "flake": false,
       "locked": {
-        "lastModified": 1780327931,
-        "narHash": "sha256-AqzgDeiUE3eHDWkedRJe51E+adTWOcTFHR4q7Mm5SDs=",
+        "lastModified": 1781915104,
+        "narHash": "sha256-IOD3rpyt0HNxapVxPn+xGwF3hMlQCLpBDbX+FzZtjmw=",
         "owner": "txpipe",
         "repo": "dolos",
-        "rev": "a92d1b3382931532682aa5c35ed0cca85383e5d4",
+        "rev": "534158e2b7c7275fa1815816f4055842bca5abb6",
         "type": "github"
       },
       "original": {
         "owner": "txpipe",
-        "ref": "v1.2.0",
+        "ref": "v1.3.1",
         "repo": "dolos",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
       flake = false; # otherwise, +2k dependencies we don’t really use
     };
     dolos = {
-      url = "github:txpipe/dolos/v1.3.1";
+      url = "github:txpipe/dolos/v1.3.2";
       flake = false;
     };
     blockfrost-tests = {

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
       flake = false; # otherwise, +2k dependencies we don’t really use
     };
     dolos = {
-      url = "github:txpipe/dolos/v1.2.0";
+      url = "github:txpipe/dolos/v1.3.1";
       flake = false;
     };
     blockfrost-tests = {

--- a/nix/internal/unix.nix
+++ b/nix/internal/unix.nix
@@ -533,19 +533,9 @@ in
       mainnet = "https://aggregator.release-mainnet.api.mithril.network/aggregator";
     };
 
-    # FIXME: Dolos v1.0.0-rc.12 depends on a fjall branch that was deleted after merge:
-    # https://github.com/fjall-rs/fjall/pull/259
-    # Patch the source to use the pinned commit rev instead of the defunct branch name.
-    dolosSrc = pkgs.runCommand "dolos-src-patched" {} ''
-      cp -r ${inputs.dolos} $out
-      chmod -R +w $out
-      sed -i 's|branch = "recovery/change-flush-queueing"|rev = "2443c7bcf6f53920efef836518d76e865974c4ca"|' $out/Cargo.toml
-      sed -i 's|branch=recovery%2Fchange-flush-queueing|rev=2443c7bcf6f53920efef836518d76e865974c4ca|g' $out/Cargo.lock
-    '';
-
     dolos = craneLib.buildPackage (
       {
-        src = dolosSrc;
+        src = inputs.dolos;
         GIT_REVISION = inputs.dolos.rev;
         strictDeps = true;
         nativeBuildInputs =

--- a/nix/internal/windows.nix
+++ b/nix/internal/windows.nix
@@ -284,18 +284,8 @@ in rec {
     stripRoot = false;
   };
 
-  # FIXME: Dolos v1.0.0-rc.12 depends on a fjall branch that was deleted after merge:
-  # https://github.com/fjall-rs/fjall/pull/259
-  # Patch the source to use the pinned commit rev instead of the defunct branch name.
-  dolosSrc = pkgs.runCommand "dolos-src-patched" {} ''
-    cp -r ${inputs.dolos} $out
-    chmod -R +w $out
-    sed -i 's|branch = "recovery/change-flush-queueing"|rev = "2443c7bcf6f53920efef836518d76e865974c4ca"|' $out/Cargo.toml
-    sed -i 's|branch=recovery%2Fchange-flush-queueing|rev=2443c7bcf6f53920efef836518d76e865974c4ca|g' $out/Cargo.lock
-  '';
-
   dolos = craneLib.buildPackage {
-    src = dolosSrc;
+    src = inputs.dolos;
     GIT_REVISION = inputs.dolos.rev;
     strictDeps = true;
 


### PR DESCRIPTION
## Context

This is just for the devshell and the desktop app.

We still have to unignore the `epochs-latest-parameters-latest-epoch_a73a0c95ff80` test once Dolos is updated on the GitHub Runner.