### PR TITLE
fix(fmt): always warn when the git pre-commit hook isn't installed

### DIFF
--- a/nix/devshells.nix
+++ b/nix/devshells.nix
@@ -186,7 +186,9 @@ in {
         # contributor's own setup or hooks installed by other tooling.
         installed=
         current="$(git -C "$PRJ_ROOT" config --get core.hooksPath 2>/dev/null || true)"
-        if [[ -z "$current" || "$current" == /nix/store/*-blockfrost-platform-git-hooks ]] ; then
+        if [[ "$current" == "${gitHooks}" ]] ; then
+          installed=1
+        elif [[ -z "$current" || "$current" == /nix/store/*-blockfrost-platform-git-hooks ]] ; then
           if git -C "$PRJ_ROOT" config --local core.hooksPath ${gitHooks} ; then
             installed=1
           else

--- a/nix/devshells.nix
+++ b/nix/devshells.nix
@@ -184,14 +184,21 @@ in {
         # Only manage `core.hooksPath` when it's unset or still points at a
         # (possibly older) version of our own hooks; never clobber a
         # contributor's own setup or hooks installed by other tooling.
+        installed=
         current="$(git -C "$PRJ_ROOT" config --get core.hooksPath 2>/dev/null || true)"
         if [[ -z "$current" || "$current" == /nix/store/*-blockfrost-platform-git-hooks ]] ; then
-          # Don't abort devshell startup if .git is read-only
-          git -C "$PRJ_ROOT" config --local core.hooksPath ${gitHooks} || true
+          if git -C "$PRJ_ROOT" config --local core.hooksPath ${gitHooks} ; then
+            installed=1
+          else
+            echo >&2 "note: couldn't set git core.hooksPath (is .git read-only?)"
+          fi
         else
           echo >&2 "note: leaving your existing git core.hooksPath ($current) untouched"
+        fi
+        if [[ -z "$installed" ]] ; then
           echo >&2 "hint: the blockfrost-platform pre-commit (treefmt) hook was not installed"
         fi
+        unset installed current
       fi
     '';
   };


### PR DESCRIPTION
## Context

A follow-up to:
- #595 

A failed `git config` write (e.g. read-only `.git`) was swallowed by `|| true`, leaving only Git's confusing raw error with no hint the `treefmt` hook was skipped.

Messaging with a read-only `.git` (e.g. in an agent sandbox):

- before:

  ```
  error: could not lock config file .git/config: Read-only file system
  ```

- after:

  ```
  error: could not lock config file .git/config: Read-only file system
  note: couldn't set git core.hooksPath (is .git read-only?)
  hint: the blockfrost-platform pre-commit (treefmt) hook was not installed
  ```