### PR TITLE
fix(gateway): add a `database.pool_max_size` config field

### DIFF
--- a/crates/gateway/CHANGELOG.md
+++ b/crates/gateway/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Support for optional `X-SKIP-PORT-CHECK` header. When set to the value of the `SKIP_PORT_CHECK_SECRET` environment variable, the server skips the TCP port reachability check and accepts the provided port as-is.
 - Use a WebSocket load balancer to allow connections from behind NAT(s)
 - `project_id` and `connection_string` can also be fetched from a file
+- Required `database.pool_max_size` config value (overridable via `BLOCKFROST_GATEWAY_DB_POOL_MAX_SIZE`) that caps the PostgreSQL connection pool per gateway instance
 
 ## [1.3.3] - 2025-03-12
 

--- a/crates/gateway/README.md
+++ b/crates/gateway/README.md
@@ -20,6 +20,7 @@ log_level = 'info'
 
 [database]
 connection_string = 'postgresql://user:pass@host:port/db'
+pool_max_size = 6
 
 [blockfrost]
 project_id = 'BLOCKFROST_PROJECT_ID'
@@ -35,6 +36,7 @@ The following environment variables can be used to override config file:
 - `BLOCKFROST_GATEWAY_SERVER_ADDRESS` — The server address (e.g., `0.0.0.0:3000`)
 - `BLOCKFROST_GATEWAY_SERVER_LOG_LEVEL` — The log level (e.g., `info`, `debug`, `warn`)
 - `BLOCKFROST_GATEWAY_DB_CONNECTION_STRING` — The database connection string (PostgreSQL supported)
+- `BLOCKFROST_GATEWAY_DB_POOL_MAX_SIZE` — Maximum PostgreSQL connections held by this gateway
 - `BLOCKFROST_GATEWAY_PROJECT_ID` — The Blockfrost project ID
 - `BLOCKFROST_GATEWAY_NFT_ASSET` — Hex of the NFT asset used for validating license
 

--- a/crates/gateway/config/development.toml
+++ b/crates/gateway/config/development.toml
@@ -15,6 +15,10 @@ peer_secret = 'change-me-to-a-long-random-string'
 [database]
 connection_string = 'postgresql://user:pass@host:port/db'
 #connection_string_file = '/run/keys/blockfrost-gateway-db-connection-string'
+# Maximum PostgreSQL connections held by this gateway. The sum across all
+# gateway instances must stay below the database connection limit (minus any
+# slots reserved for superusers).
+pool_max_size = 6
 
 [blockfrost]
 project_id = 'preview_BLOCKFROST_PROJECT_ID'

--- a/crates/gateway/config/production.toml
+++ b/crates/gateway/config/production.toml
@@ -15,6 +15,10 @@ peer_secret = 'change-me-to-a-long-random-string'
 [database]
 connection_string = 'postgresql://user:pass@host:port/db'
 #connection_string_file = '/run/keys/blockfrost-gateway-db-connection-string'
+# Maximum PostgreSQL connections held by this gateway. The sum across all
+# gateway instances must stay below the database connection limit (minus any
+# slots reserved for superusers).
+pool_max_size = 6
 
 [blockfrost]
 project_id = 'BLOCKFROST_PROJECT_ID'

--- a/crates/gateway/src/config.rs
+++ b/crates/gateway/src/config.rs
@@ -40,10 +40,6 @@ pub struct ServerInput {
 pub struct DbInput {
     pub connection_string: Option<String>,
     pub connection_string_file: Option<String>,
-    /// Maximum number of connections this gateway keeps in its PostgreSQL pool.
-    /// The sum across all gateway instances must stay below the database's
-    /// connection limit (minus any slots reserved for superusers). Must be
-    /// non-zero; a `pool_max_size = 0` is rejected at config-load time.
     pub pool_max_size: NonZeroUsize,
 }
 

--- a/crates/gateway/src/config.rs
+++ b/crates/gateway/src/config.rs
@@ -4,6 +4,7 @@ use clap::Parser;
 use serde::{Deserialize, Deserializer};
 use std::env::var;
 use std::fs::read_to_string;
+use std::num::NonZeroUsize;
 use std::str::FromStr;
 use std::{fs, path::PathBuf};
 use tracing::Level;
@@ -39,7 +40,11 @@ pub struct ServerInput {
 pub struct DbInput {
     pub connection_string: Option<String>,
     pub connection_string_file: Option<String>,
-    pub pool_max_size: usize,
+    /// Maximum number of connections this gateway keeps in its PostgreSQL pool.
+    /// The sum across all gateway instances must stay below the database's
+    /// connection limit (minus any slots reserved for superusers). Must be
+    /// non-zero; a `pool_max_size = 0` is rejected at config-load time.
+    pub pool_max_size: NonZeroUsize,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -74,7 +79,7 @@ pub struct Server {
 #[derive(Debug, Deserialize, Clone)]
 pub struct Db {
     pub connection_string: String,
-    pub pool_max_size: usize,
+    pub pool_max_size: NonZeroUsize,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -260,8 +265,8 @@ fn override_with_env(config: Config) -> Config {
         var("BLOCKFROST_GATEWAY_DB_CONNECTION_STRING").unwrap_or(config.database.connection_string);
     let pool_max_size = var("BLOCKFROST_GATEWAY_DB_POOL_MAX_SIZE")
         .map(|s| {
-            s.parse::<usize>()
-                .expect("BLOCKFROST_GATEWAY_DB_POOL_MAX_SIZE must be a positive integer")
+            s.parse::<NonZeroUsize>()
+                .expect("BLOCKFROST_GATEWAY_DB_POOL_MAX_SIZE must be an integer greater than 0")
         })
         .unwrap_or(config.database.pool_max_size);
     let project_id = var("BLOCKFROST_GATEWAY_PROJECT_ID").unwrap_or(config.blockfrost.project_id);
@@ -328,5 +333,29 @@ mod tests {
         std::fs::remove_file(&path).ok();
 
         read_secret_file(&path.to_string_lossy(), "test secret");
+    }
+
+    #[test]
+    fn pool_max_size_rejects_zero() {
+        let toml = r#"
+            connection_string = 'postgresql://user:pass@host:port/db'
+            pool_max_size = 0
+        "#;
+        let err = toml::from_str::<DbInput>(toml)
+            .expect_err("pool_max_size = 0 must be rejected at config-load time");
+        assert!(
+            err.to_string().contains("pool_max_size"),
+            "error should mention the offending field, got: {err}"
+        );
+    }
+
+    #[test]
+    fn pool_max_size_accepts_positive() {
+        let toml = r#"
+            connection_string = 'postgresql://user:pass@host:port/db'
+            pool_max_size = 6
+        "#;
+        let db: DbInput = toml::from_str(toml).expect("valid pool_max_size must parse");
+        assert_eq!(db.pool_max_size.get(), 6);
     }
 }

--- a/crates/gateway/src/config.rs
+++ b/crates/gateway/src/config.rs
@@ -39,6 +39,7 @@ pub struct ServerInput {
 pub struct DbInput {
     pub connection_string: Option<String>,
     pub connection_string_file: Option<String>,
+    pub pool_max_size: usize,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -73,6 +74,7 @@ pub struct Server {
 #[derive(Debug, Deserialize, Clone)]
 pub struct Db {
     pub connection_string: String,
+    pub pool_max_size: usize,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -168,7 +170,10 @@ pub fn load_config(path: PathBuf) -> Config {
             peer_urls,
             peer_secret,
         },
-        database: Db { connection_string },
+        database: Db {
+            connection_string,
+            pool_max_size: toml_config.database.pool_max_size,
+        },
         blockfrost: Blockfrost {
             project_id,
             nft_asset: toml_config.blockfrost.nft_asset,
@@ -253,6 +258,12 @@ fn override_with_env(config: Config) -> Config {
         .unwrap_or_else(|_| config.server.log_level.to_string());
     let db_connection =
         var("BLOCKFROST_GATEWAY_DB_CONNECTION_STRING").unwrap_or(config.database.connection_string);
+    let pool_max_size = var("BLOCKFROST_GATEWAY_DB_POOL_MAX_SIZE")
+        .map(|s| {
+            s.parse::<usize>()
+                .expect("BLOCKFROST_GATEWAY_DB_POOL_MAX_SIZE must be a positive integer")
+        })
+        .unwrap_or(config.database.pool_max_size);
     let project_id = var("BLOCKFROST_GATEWAY_PROJECT_ID").unwrap_or(config.blockfrost.project_id);
     let nft_asset = var("BLOCKFROST_GATEWAY_NFT_ASSET").unwrap_or(config.blockfrost.nft_asset);
     let network = network_from_project_id(&project_id).expect("invalid Blockfrost project_id");
@@ -277,6 +288,7 @@ fn override_with_env(config: Config) -> Config {
         },
         database: Db {
             connection_string: db_connection,
+            pool_max_size,
         },
         blockfrost: Blockfrost {
             project_id,

--- a/crates/gateway/src/db.rs
+++ b/crates/gateway/src/db.rs
@@ -16,9 +16,10 @@ pub struct DB {
 }
 
 impl DB {
-    pub async fn new(database_url: &str) -> Self {
+    pub async fn new(database_url: &str, pool_max_size: usize) -> Self {
         let manager = Manager::new(database_url, deadpool_diesel::Runtime::Tokio1);
         let pool = Pool::builder(manager)
+            .max_size(pool_max_size)
             .build()
             .expect("Failed to create pool.");
 

--- a/crates/gateway/src/db.rs
+++ b/crates/gateway/src/db.rs
@@ -7,6 +7,7 @@ use deadpool_diesel::postgres::{Manager, Pool};
 use diesel::prelude::*;
 use diesel_migrations::{EmbeddedMigrations, MigrationHarness, embed_migrations};
 use schema::users::dsl::*;
+use std::num::NonZeroUsize;
 
 pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!("migrations/");
 
@@ -16,10 +17,10 @@ pub struct DB {
 }
 
 impl DB {
-    pub async fn new(database_url: &str, pool_max_size: usize) -> Self {
+    pub async fn new(database_url: &str, pool_max_size: NonZeroUsize) -> Self {
         let manager = Manager::new(database_url, deadpool_diesel::Runtime::Tokio1);
         let pool = Pool::builder(manager)
-            .max_size(pool_max_size)
+            .max_size(pool_max_size.get())
             .build()
             .expect("Failed to create pool.");
 

--- a/crates/gateway/src/main.rs
+++ b/crates/gateway/src/main.rs
@@ -33,7 +33,11 @@ async fn main() -> Result<()> {
 
     setup_tracing(config.server.log_level, "BLOCKFROST_GATEWAY_LOG_TARGET");
 
-    let pool = DB::new(&config.database.connection_string).await;
+    let pool = DB::new(
+        &config.database.connection_string,
+        config.database.pool_max_size,
+    )
+    .await;
     let blockfrost_api = blockfrost::BlockfrostAPI::new(&config.blockfrost.project_id);
     let hydras_manager = if let Some(hydra_platform_config) = &config.hydra_platform {
         Some(

--- a/nix/internal/hydra-bridge-gateway-test.sh
+++ b/nix/internal/hydra-bridge-gateway-test.sh
@@ -315,6 +315,7 @@ peer_secret = '${peer_secret}'
 
 [database]
 connection_string = 'postgresql://not-used-with-dev-mock-db@localhost/dummy'
+pool_max_size = 6
 
 [blockfrost]
 project_id = '${BLOCKFROST_PROJECT_ID}'

--- a/nix/internal/hydra-platform-gateway-test.sh
+++ b/nix/internal/hydra-platform-gateway-test.sh
@@ -310,6 +310,7 @@ peer_secret = '${peer_secret}'
 
 [database]
 connection_string = 'postgresql://not-used-with-dev-mock-db@localhost/dummy'
+pool_max_size = 6
 
 [blockfrost]
 project_id = '${BLOCKFROST_PROJECT_ID}'

--- a/nix/internal/platform-gateway-ha-test.sh
+++ b/nix/internal/platform-gateway-ha-test.sh
@@ -125,6 +125,7 @@ peer_secret = '${peer_secret}'
 
 [database]
 connection_string = 'postgresql://not-used-with-dev-mock-db@localhost/dummy'
+pool_max_size = 6
 
 [blockfrost]
 project_id = 'preview00000000000000000000000000'
@@ -143,6 +144,7 @@ peer_secret = '${peer_secret}'
 
 [database]
 connection_string = 'postgresql://not-used-with-dev-mock-db@localhost/dummy'
+pool_max_size = 6
 
 [blockfrost]
 project_id = 'preview00000000000000000000000000'

--- a/nix/internal/unix.nix
+++ b/nix/internal/unix.nix
@@ -778,6 +778,7 @@ in
 
             [database]
             connection_string = 'postgresql://unused:unused@127.0.0.1:5432/unused'
+            pool_max_size = 6
 
             [blockfrost]
             project_id = '${network}00000000000000000000000000000000'


### PR DESCRIPTION
## Context

We had a production issue where adding a third `blockfrost-gateway` server exhausted the maximum od 22 connections in DigitalOcean.

Without specifying it, the value defaults to `2 * num_cpus`, which was too much.

Found by @hlolli and @opacular.