### PR TITLE
chore(nixpkgs): update to the `nixos-26.05` channel

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -310,16 +310,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1782847189,
-        "narHash": "sha256-twXPFqFsrrY5r28Zh7Homgcp2gUMBgQ6WDS98Q/3xFI=",
+        "lastModified": 1784011430,
+        "narHash": "sha256-lDebytrYdd47IBLwvNOD+6AGeoqZ78CIKlp70hzW280=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b6018f87da91d19d0ab4cf979885689b469cdd41",
+        "rev": "8eeec934ae0dbeca3d7868c059568a65c08b2fc3",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-26.05";
     flake-parts.url = "github:hercules-ci/flake-parts";
     treefmt-nix = {
       url = "github:numtide/treefmt-nix";

--- a/nix/internal/unix.nix
+++ b/nix/internal/unix.nix
@@ -689,9 +689,7 @@ in
     make-blockfrost-tests = {
       network,
       ignorelistOnly ? false,
-    }: let
-      inherit (pkgs) nodePackages;
-    in
+    }:
       pkgs.writeShellApplication {
         name =
           if ignorelistOnly
@@ -705,8 +703,8 @@ in
           bash
           coreutils
           gnugrep
-          nodePackages.nodejs
-          nodePackages.yarn
+          nodejs
+          yarn
           curl
           jq
           (python3.withPackages (ps: with ps; [portpicker]))

--- a/nix/internal/windows.nix
+++ b/nix/internal/windows.nix
@@ -233,7 +233,8 @@ in rec {
   # depends on the `unix` package, see <https://github.com/cardano-scaling/hydra/issues/2360>.
   bundle =
     pkgs.runCommand "bundle" {
-      buildInputs = [pkgs.wine64];
+      # `wineWow64Packages` runs both 32- and 64-bit executables.
+      buildInputs = [pkgs.wineWow64Packages.stable];
       WINEDEBUG = "-all";
       WINEDLLOVERRIDES = "mscoree,mshtml="; # don't ask about Mono or Gecko
     } ''
@@ -242,7 +243,7 @@ in rec {
       mkdir -p $out
       cp -r ${packageWithIcon}/. $out/.
       cp -r ${dolos}/bin/. $out/.
-      wine64 $out/${packageName.pname}.exe --version
+      wine $out/${packageName.pname}.exe --version
     '';
 
   archive =


### PR DESCRIPTION
## Context

`blockfrost-ops` set `abort-on-warn = true`, and with the newest Crane, we are causing:

```
evaluation warning: crane requires at least nixpkgs-26.05, supplied nixpkgs-25.11
```

This PR updates the Nixpkgs channel to get rid of this warning.