### PR TITLE
fix(gateway): drop redundant `_platform_` infix from relay metric names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Added
 
-- Gateway: per-platform `blockfrost_gateway_relay_healthy`, `blockfrost_gateway_relay_data_node_up`, and `blockfrost_gateway_relay_info` metrics in `GET /metrics` (and the same data points in `GET /stats`)
+- Gateway: per-relay `blockfrost_gateway_relay_healthy`, `blockfrost_gateway_relay_data_node_up`, and `blockfrost_gateway_relay_info` metrics in `GET /metrics` (and the same data points in `GET /stats`)
 - New endpoints proxied to the data node: `/accounts/{stake_address}/utxos`, `/addresses/{address}`, and `/blocks/slot/{slot_number}`
 - `--max-response-body-bytes` to configure the maximum proxied response body size (default 10 MiB)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Added
 
-- Gateway: per-platform `blockfrost_gateway_relay_platform_healthy`, `blockfrost_gateway_relay_platform_data_node_connected`, and `blockfrost_gateway_relay_platform_info` metrics in `GET /metrics` (and the same data points in `GET /stats`)
+- Gateway: per-platform `blockfrost_gateway_relay_healthy`, `blockfrost_gateway_relay_data_node_up`, and `blockfrost_gateway_relay_info` metrics in `GET /metrics` (and the same data points in `GET /stats`)
 - New endpoints proxied to the data node: `/accounts/{stake_address}/utxos`, `/addresses/{address}`, and `/blocks/slot/{slot_number}`
 - `--max-response-body-bytes` to configure the maximum proxied response body size (default 10 MiB)
 

--- a/crates/gateway/CHANGELOG.md
+++ b/crates/gateway/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Added
 
-- Per-relay `blockfrost_gateway_relay_platform_healthy`, `blockfrost_gateway_relay_platform_data_node_connected`, and `blockfrost_gateway_relay_platform_info` metrics in `GET /metrics` (and the same data points in `GET /stats`)
+- Per-relay `blockfrost_gateway_relay_healthy`, `blockfrost_gateway_relay_data_node_up`, and `blockfrost_gateway_relay_info` metrics in `GET /metrics` (and the same data points in `GET /stats`)
 - Prometheus metrics endpoint `GET /metrics` exposing per-relay stats (connection status, WebSocket RTT, connected-since timestamp, request/response counters) and PostgreSQL connection-pool gauges (max size, open, available, waiting)
 - Prometheus counter `blockfrost_gateway_http_requests_total` with `method`, `route`, and `status_code` labels for Gateway API requests
 - `blockfrost_gateway_build_info` metric exposing the Gateway version and git revision

--- a/crates/gateway/src/api/metrics.rs
+++ b/crates/gateway/src/api/metrics.rs
@@ -76,13 +76,13 @@ const RELAY_METRICS: &[RelayMetric] = &[
         |_| Some("1".to_string()),
     ),
     (
-        "blockfrost_gateway_relay_platform_healthy",
+        "blockfrost_gateway_relay_healthy",
         "gauge",
         "Whether the relay’s Platform reported healthy on the last periodic check (absent until the first check completes).",
         |r| r.healthy.map(|h| u8::from(h).to_string()),
     ),
     (
-        "blockfrost_gateway_relay_platform_data_node_connected",
+        "blockfrost_gateway_relay_data_node_up",
         "gauge",
         "Whether the relay’s Platform had a data node connected on the last periodic check.",
         |r| r.has_data_node.map(|h| u8::from(h).to_string()),
@@ -206,7 +206,7 @@ pub(crate) async fn render_prometheus(
 
     // The version metric needs an extra label, so it doesn’t fit `RELAY_METRICS`:
     {
-        let name = "blockfrost_gateway_relay_platform_info";
+        let name = "blockfrost_gateway_relay_info";
         writeln!(
             out,
             "# HELP {name} Version of the Platform run by the relay, in the `version` label (value is always 1)."
@@ -326,13 +326,13 @@ mod tests {
             "blockfrost_gateway_relay_up{relay=\"Icebreaker2\",api_prefix=\"513d26a9-9fea-4fbd-8ff4-d9ab00875c59\"} 1"
         ));
         assert!(out.contains(
-            "blockfrost_gateway_relay_platform_healthy{relay=\"Icebreaker2\",api_prefix=\"513d26a9-9fea-4fbd-8ff4-d9ab00875c59\"} 1"
+            "blockfrost_gateway_relay_healthy{relay=\"Icebreaker2\",api_prefix=\"513d26a9-9fea-4fbd-8ff4-d9ab00875c59\"} 1"
         ));
         assert!(out.contains(
-            "blockfrost_gateway_relay_platform_data_node_connected{relay=\"Icebreaker2\",api_prefix=\"513d26a9-9fea-4fbd-8ff4-d9ab00875c59\"} 0"
+            "blockfrost_gateway_relay_data_node_up{relay=\"Icebreaker2\",api_prefix=\"513d26a9-9fea-4fbd-8ff4-d9ab00875c59\"} 0"
         ));
         assert!(out.contains(
-            "blockfrost_gateway_relay_platform_info{relay=\"Icebreaker2\",api_prefix=\"513d26a9-9fea-4fbd-8ff4-d9ab00875c59\",version=\"1.2.3\"} 1"
+            "blockfrost_gateway_relay_info{relay=\"Icebreaker2\",api_prefix=\"513d26a9-9fea-4fbd-8ff4-d9ab00875c59\",version=\"1.2.3\"} 1"
         ));
         assert!(
             !out.contains("blockfrost_gateway_relay_network_rtt_seconds{relay=\"Icebreaker2\"")
@@ -352,11 +352,11 @@ mod tests {
             .await
             .expect("render metrics");
 
-        assert!(out.contains("# TYPE blockfrost_gateway_relay_platform_healthy gauge"));
-        assert!(out.contains("# TYPE blockfrost_gateway_relay_platform_info gauge"));
-        assert!(!out.contains("blockfrost_gateway_relay_platform_healthy{"));
-        assert!(!out.contains("blockfrost_gateway_relay_platform_data_node_connected{"));
-        assert!(!out.contains("blockfrost_gateway_relay_platform_info{"));
+        assert!(out.contains("# TYPE blockfrost_gateway_relay_healthy gauge"));
+        assert!(out.contains("# TYPE blockfrost_gateway_relay_info gauge"));
+        assert!(!out.contains("blockfrost_gateway_relay_healthy{"));
+        assert!(!out.contains("blockfrost_gateway_relay_data_node_up{"));
+        assert!(!out.contains("blockfrost_gateway_relay_info{"));
     }
 
     #[test]


### PR DESCRIPTION
## Context

Follow-up to:
- #606

Commit fbdfef518c411565d7f69cb8ff40a3c6402c4f21 (by Copilot in #606) renamed three per-relay metrics to insert a `_platform_` segment, while [claiming it was "more consistent"](https://github.com/blockfrost/blockfrost-platform/pull/606#issuecomment-4969049737). It's the opposite, since "relay" already means Platform. Furthermore, the segment was applied to only 3 of the 9 relay metrics.