### PR TITLE
Move Mithril client to the IntersectMBO registry and cardano-db v2 backend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   init-node:
-    image: ghcr.io/input-output-hk/mithril-client:2506.0-2627f17
+    image: ghcr.io/intersectmbo/mithril-client:2617.0-2478748
     entrypoint: /app/bin/entrypoint.sh
     user: "${UID}:${GID}"
     environment:

--- a/docker/mithril-entrypoint.sh
+++ b/docker/mithril-entrypoint.sh
@@ -37,10 +37,10 @@ apt install jq curl -y
 
 # ---------------------------------------------------------------------------- #
 
-snapshotDigest=$(/app/bin/mithril-client cardano-db snapshot list --json | jq -r ".[0].digest")
+snapshotDigest=$(/app/bin/mithril-client cardano-db snapshot list --json | jq -r ".[0].hash")
 export snapshotDigest
 
-GENESIS_VERIFICATION_KEY=$(curl -fsSL "https://raw.githubusercontent.com/input-output-hk/mithril/refs/heads/main/mithril-infra/configuration/${MITHRIL_NETWORK}/genesis.vkey")
+GENESIS_VERIFICATION_KEY=$(curl -fsSL "https://raw.githubusercontent.com/IntersectMBO/mithril/refs/heads/main/mithril-infra/configuration/${MITHRIL_NETWORK}/genesis.vkey")
 export GENESIS_VERIFICATION_KEY
 
 /app/bin/mithril-client cardano-db download "$snapshotDigest" --download-dir "$UNPACK_DIR" --json

--- a/flake.lock
+++ b/flake.lock
@@ -234,13 +234,13 @@
       "locked": {
         "lastModified": 1776926918,
         "narHash": "sha256-muV2LpheC4OZsU1ipL9j6TmjGufMpGrXzvon+eWahgg=",
-        "owner": "input-output-hk",
+        "owner": "IntersectMBO",
         "repo": "mithril",
         "rev": "2478748ea9771baed8181ef0938c78f79ed60760",
         "type": "github"
       },
       "original": {
-        "owner": "input-output-hk",
+        "owner": "IntersectMBO",
         "ref": "2617.0",
         "repo": "mithril",
         "type": "github"

--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,7 @@
       url = "github:blockfrost/blockfrost-tests";
       flake = false;
     };
-    mithril.url = "github:input-output-hk/mithril/2617.0";
+    mithril.url = "github:IntersectMBO/mithril/2617.0";
     testgen-hs = {
       url = "github:blockfrost/testgen-hs/11.0.1.0"; # make sure it follows cardano-node
       flake = false; # otherwise, +2k dependencies we don’t really use


### PR DESCRIPTION
This PR moves the Mithril client to `IntersectMBO` and adapts to the `cardano-db` v2 backend. The release published on the new namespace (`2617.0`) removed the v1 `CardanoImmutableFilesFull` backend that `2506.0` used, so a plain image bump would break the entrypoint.
- Repoints the `init-node` image in `docker-compose.yml` from `ghcr.io/input-output-hk/mithril-client:2506.0-2627f17` to `ghcr.io/intersectmbo/mithril-client:2617.0-2478748`:
  - the old `input-output-hk` namespace is frozen
  - `2506.0` is not published there, so this also bumps to the current release
- Adapts `docker/mithril-entrypoint.sh` to the v2 backend:
  - `snapshot list --json` now exposes `hash` (not `digest`)
  - repoints the genesis verification key URL to `IntersectMBO`