### PR TITLE
perf(gateway): index `requests(user_id, created_at)` to fix slow `INSERT`s

### DIFF
--- a/crates/gateway/migrations/2026-07-29-121100_index_requests_user_id_created_at/down.sql
+++ b/crates/gateway/migrations/2026-07-29-121100_index_requests_user_id_created_at/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_requests_user_id_created_at;

--- a/crates/gateway/migrations/2026-07-29-121100_index_requests_user_id_created_at/metadata.toml
+++ b/crates/gateway/migrations/2026-07-29-121100_index_requests_user_id_created_at/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/crates/gateway/migrations/2026-07-29-121100_index_requests_user_id_created_at/up.sql
+++ b/crates/gateway/migrations/2026-07-29-121100_index_requests_user_id_created_at/up.sql
@@ -1,0 +1,10 @@
+-- Speeds up "latest request per user" lookups (admin/dashboard LATERAL joins)
+-- and the requests.user_id foreign-key checks. Without it, a query like
+--   SELECT ... FROM requests WHERE user_id = $1 ORDER BY created_at DESC LIMIT 1
+-- degrades into a sequential scan + sort over the whole (multi-million-row)
+-- table, pegging a CPU core and blocking concurrent INSERTs.
+--
+-- CONCURRENTLY avoids taking a lock that would block INSERTs while the index
+-- builds; it cannot run inside a transaction (see metadata.toml).
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_requests_user_id_created_at
+    ON requests (user_id, created_at DESC);

--- a/crates/integration_tests/tests/data/ignored_tests.json
+++ b/crates/integration_tests/tests/data/ignored_tests.json
@@ -227,10 +227,6 @@
     {
       "_comment": "epochs/latest/parameters -- Dolos returns outdated PlutusV1/V2/V3 cost models compared to the real Blockfrost API after the latest mainnet protocol update (missing new builtins like andByteString/expModInteger/scaleValue and old values for equalsByteString and divide/mod/quotientInteger)",
       "id": "epochs-latest-parameters_a73a0c95ff80"
-    },
-    {
-      "_comment": "pools/pool1pu5jlj4q9w9jlxeu370a3c9myx47md5j5m2str0naunn2q3lkdy (= pools/0f292fcaa02b8b2f9b3c8f9fd8e0bb21abedb692a6d5058df3ef2735) -- live_pledge is dynamic and fell below the fixture's configured range",
-      "id": "pools-pool-id-best-pool_ed86d68945e0"
     }
   ],
   "preprod": [
@@ -315,10 +311,6 @@
     {
       "_comment": "assets/ddd01d9531fcc25e3ca4b6429318c2cc374dbdbcf5e99c1c1e5da1ff444f4e545350414d/addresses -- Dolos returns an empty array [] for a valid asset that was never minted on-chain, while the real Blockfrost API returns HTTP 404 Not Found",
       "id": "assets-addresses-valid-not-on-chain-asset_3ad55423382f"
-    },
-    {
-      "_comment": "pools/pool1p73yrd7vzwkkjd2rff4g683smhlm3jkg45f2hwm79cke6uxxwq9 (= pools/0fa241b7cc13ad6935434a6a8d1e30ddffb8cac8ad12abbb7e2e2d9d) -- live_size is dynamic and fell below the fixture's configured range",
-      "id": "pools-pool-id-multiple-times-deregistered-pool_bf237a8f6b25"
     }
   ]
 }


### PR DESCRIPTION
`INSERT`s into `requests` were intermittently taking 35-72s while a CPU core pegged at 100% for up to an hour. The cause was an external admin/dashboard query doing a per-user `LATERAL` lookup of the most recent request:

```
SELECT ... FROM users u LEFT JOIN LATERAL (
  SELECT ... FROM requests r WHERE r.user_id = u.id
  ORDER BY r.created_at DESC LIMIT 1
) lr ON true ...
```

Found by @hlolli.