### PR TITLE
fix(nix): set `meta.mainProgram` on `hydra-node` for `lib.getExe`

### DIFF
--- a/nix/internal/unix.nix
+++ b/nix/internal/unix.nix
@@ -905,6 +905,7 @@ in
 
     hydra-node = lib.recursiveUpdate hydra-flake.packages.${targetSystem}.hydra-node {
       meta.description = "Layer 2 scalability solution for Cardano";
+      meta.mainProgram = "hydra-node";
     };
 
     hydra-test = pkgs.writeShellApplication {


### PR DESCRIPTION
`hydra-node` comes from the Hydra flake, which doesn't set `meta.mainProgram`, so every `lib.getExe hydra-node` emitted a deprecation warning during evaluation.