### PR TITLE
chore: update Mithril to 2630.0 (Cardano DB v2)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   init-node:
-    image: ghcr.io/intersectmbo/mithril-client:2617.0-2478748
+    image: ghcr.io/intersectmbo/mithril-client:2630.0-23e124d
     entrypoint: /app/bin/entrypoint.sh
     user: "${UID}:${GID}"
     environment:

--- a/docker/mithril-entrypoint.sh
+++ b/docker/mithril-entrypoint.sh
@@ -12,6 +12,11 @@ if [[ -z ${UNPACK_DIR:-} ]]; then
   exit 1
 fi
 
+# Mithril distribution tag; keep in sync with the `mithril-client` image tag in
+# `docker-compose.yml`. Used to pin the verification keys below to this exact
+# release instead of tracking `main` (the client binary doesn't expose it).
+MITHRIL_TAG="2630.0"
+
 if [ -d "$UNPACK_DIR/db" ]; then
   echo "Directory $UNPACK_DIR/db exists, nothing to do. If you are having issues with your cardano node database please remove the volume and restart"
   exit 0
@@ -33,14 +38,23 @@ export AGGREGATOR_ENDPOINT="https://aggregator.${MITHRIL_NETWORK}.api.mithril.ne
 # ---------------------------------------------------------------------------- #
 
 apt update
-apt install jq curl -y
+apt install curl -y
 
 # ---------------------------------------------------------------------------- #
 
-snapshotDigest=$(/app/bin/mithril-client cardano-db snapshot list --json | jq -r ".[0].hash")
-export snapshotDigest
+vkey_base="https://raw.githubusercontent.com/IntersectMBO/mithril/${MITHRIL_TAG}/mithril-infra/configuration/${MITHRIL_NETWORK}"
 
-GENESIS_VERIFICATION_KEY=$(curl -fsSL "https://raw.githubusercontent.com/IntersectMBO/mithril/refs/heads/main/mithril-infra/configuration/${MITHRIL_NETWORK}/genesis.vkey")
+GENESIS_VERIFICATION_KEY=$(curl -fsSL "${vkey_base}/genesis.vkey")
 export GENESIS_VERIFICATION_KEY
 
-/app/bin/mithril-client cardano-db download "$snapshotDigest" --download-dir "$UNPACK_DIR" --json
+ANCILLARY_VERIFICATION_KEY=$(curl -fsSL "${vkey_base}/ancillary.vkey")
+export ANCILLARY_VERIFICATION_KEY
+
+# The Cardano database v1 backend was dropped in Mithril distribution 2630.0, so
+# we use the v2 backend (now the default). Ancillary files carry the ledger
+# state that lets `cardano-node` start without re-syncing from genesis, so we
+# include them; that in turn requires the ancillary verification key.
+/app/bin/mithril-client cardano-db download latest \
+  --include-ancillary \
+  --download-dir "$UNPACK_DIR" \
+  --json

--- a/flake.lock
+++ b/flake.lock
@@ -83,11 +83,11 @@
     },
     "crane_2": {
       "locked": {
-        "lastModified": 1776635034,
-        "narHash": "sha256-OEOJrT3ZfwbChzODfIH4GzlNTtOFuZFWPtW7jIeR8xU=",
+        "lastModified": 1783203018,
+        "narHash": "sha256-G6R9IT/xwFuu+CYBWDUAok6AdC4ERC4ZfPPFtEpxnZE=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "dc7496d8ea6e526b1254b55d09b966e94673750f",
+        "rev": "80db5bdc391be8a1794f6d8a2d56e3a84ebcede2",
         "type": "github"
       },
       "original": {
@@ -193,11 +193,11 @@
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
-        "lastModified": 1775087534,
-        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -232,16 +232,16 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1776926918,
-        "narHash": "sha256-muV2LpheC4OZsU1ipL9j6TmjGufMpGrXzvon+eWahgg=",
+        "lastModified": 1785407305,
+        "narHash": "sha256-8Ay4GLKQGeJwGQPLliUNvgfkKCHFVUeASWFu/e0SxqM=",
         "owner": "IntersectMBO",
         "repo": "mithril",
-        "rev": "2478748ea9771baed8181ef0938c78f79ed60760",
+        "rev": "23e124d99320adea6eb3eca361132c6c43d59cfa",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "2617.0",
+        "ref": "2630.0",
         "repo": "mithril",
         "type": "github"
       }
@@ -264,11 +264,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776329215,
-        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
+        "lastModified": 1783279667,
+        "narHash": "sha256-/NAkDSsve+GNM0Bt6tleJdCGfsTlK89nPjkVOzZMo0s=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
+        "rev": "f205b5574fd0cb7da5b702a2da51507b7f4fdd1b",
         "type": "github"
       },
       "original": {
@@ -295,11 +295,11 @@
     },
     "nixpkgs-lib_2": {
       "locked": {
-        "lastModified": 1774748309,
-        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
+        "lastModified": 1782614948,
+        "narHash": "sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC+eBu2zKlp8=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
+        "rev": "db3f255737b94216eb71cce308e2912cf6bc2d7c",
         "type": "github"
       },
       "original": {
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776654897,
-        "narHash": "sha256-Vqi4AiJVCcBGn/RmBtRCgyH5rCxqm/w0xV9diJWF1Ic=",
+        "lastModified": 1783320166,
+        "narHash": "sha256-l7C/OsjcnWDOk2K3ssj+SBduwL67LashjBqis9+t468=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "25d75be8139815a53560745fa060909777495105",
+        "rev": "20ee15370c9256669d66968b89ee20a4b0a4e673",
         "type": "github"
       },
       "original": {
@@ -407,11 +407,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775636079,
-        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,7 @@
       url = "github:blockfrost/blockfrost-tests";
       flake = false;
     };
-    mithril.url = "github:IntersectMBO/mithril/2617.0";
+    mithril.url = "github:IntersectMBO/mithril/2630.0";
     testgen-hs = {
       url = "github:blockfrost/testgen-hs/11.0.1.0"; # make sure it follows cardano-node
       flake = false; # otherwise, +2k dependencies we don’t really use

--- a/nix/internal/unix.nix
+++ b/nix/internal/unix.nix
@@ -490,35 +490,7 @@ in
         shellcheck $out/*.sh
       '';
 
-    # Upstream `mithril` commit 8c715446 moved `mithril-client-cli` out of the
-    # common (glibc) packages section into the `pkgsMusl != null` section, which
-    # is only non-null for `x86_64-linux`. That left `mithril-client-cli`
-    # undefined on `aarch64-linux` and Darwin, breaking our devshell there. We
-    # patch the flake source to re-add the original glibc definition. On
-    # `x86_64-linux` we keep the upstream (musl, static) build untouched.
-    patchedMithrilFlake = let
-      unpatched = inputs.mithril;
-    in
-      (import inputs.flake-compat {
-        src =
-          if targetSystem == "x86_64-linux"
-          then unpatched
-          else {
-            outPath = toString (pkgs.runCommand "mithril-src-patched" {} ''
-              cp -r ${unpatched} $out
-              chmod -R +w $out
-              cd $out
-              if ! grep -q 'mithril-end-to-end = buildPackage' flake.nix ; then
-                echo 'error: anchor for the mithril-client-cli patch not found in flake.nix' >&2
-                exit 1
-              fi
-              sed -i 's|\( *\)mithril-end-to-end = buildPackage|\1mithril-client-cli = buildPackage ./mithril-client-cli/Cargo.toml mithril.cargoArtifacts { pname = "mithril-client"; };\n\1mithril-end-to-end = buildPackage|' flake.nix
-            '');
-            inherit (unpatched) rev shortRev lastModified lastModifiedDate;
-          };
-      }).defaultNix;
-
-    mithril-client = patchedMithrilFlake.packages.${targetSystem}.mithril-client-cli;
+    mithril-client = inputs.mithril.packages.${targetSystem}.mithril-client-cli;
 
     mithrilGenesisVerificationKeys = {
       preview = builtins.readFile (inputs.mithril + "/mithril-infra/configuration/pre-release-preview/genesis.vkey");


### PR DESCRIPTION
- Drop our previous patch for their broken Darwin artifacts.

- Switch to the v2 calling convention of [2630.0](https://github.com/IntersectMBO/mithril/releases/tag/2630.0).

For more details see [this Slack announcement](https://input-output-rnd.slack.com/archives/C06J9HK7QCQ/p1785426256256349).